### PR TITLE
C++11 support

### DIFF
--- a/apps/SoapySDRProbe.cpp
+++ b/apps/SoapySDRProbe.cpp
@@ -118,13 +118,13 @@ static std::string probeChannel(SoapySDR::Device *device, const int dir, const s
     ss << "----------------------------------------------------" << std::endl;
 
     // info
-    SoapySDR::Kwargs info = device->getChannelInfo(dir, chan);
+    const auto info = device->getChannelInfo(dir, chan);
     if (info.size() > 0)
     {
         ss << "  Channel Information:" << std::endl;
-        for (SoapySDR::Kwargs::const_iterator it = info.begin(); it != info.end(); ++it)
+        for (const auto &it : info)
         {
-            ss << "    " << it->first << "=" << it->second << std::endl;
+            ss << "    " << it.first << "=" << it.second << std::endl;
         }
     }
 
@@ -210,10 +210,9 @@ std::string SoapySDRDeviceProbe(SoapySDR::Device *device)
 
     ss << "  driver=" << device->getDriverKey() << std::endl;
     ss << "  hardware=" << device->getHardwareKey() << std::endl;
-    SoapySDR::Kwargs info = device->getHardwareInfo();
-    for (SoapySDR::Kwargs::const_iterator it = info.begin(); it != info.end(); ++it)
+    for (const auto &it : device->getHardwareInfo())
     {
-        ss << "  " << it->first << "=" << it->second << std::endl;
+        ss << "  " << it.first << "=" << it.second << std::endl;
     }
 
     /*******************************************************************

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Version.hpp>
@@ -38,11 +38,8 @@ static int printInfo(void)
     std::cout << "ABI Version: v" << SoapySDR::getABIVersion() << std::endl;
     std::cout << "Install root: " << SoapySDR::getRootPath() << std::endl;
 
-    std::vector<std::string> modules = SoapySDR::listModules();
-    for (size_t i = 0; i < modules.size(); i++)
-    {
-        std::cout << "Module found: " << modules[i] << std::endl;
-    }
+    const auto modules = SoapySDR::listModules();
+    for (const auto &mod : modules) std::cout << "Module found: " << mod << std::endl;
     if (modules.empty()) std::cout << "No modules found!" << std::endl;
 
     std::cout << "Loading modules... " << std::flush;
@@ -50,11 +47,8 @@ static int printInfo(void)
     std::cout << "done" << std::endl;
 
     std::cout << "Available factories...";
-    const SoapySDR::FindFunctions factories = SoapySDR::Registry::listFindFunctions();
-    for (SoapySDR::FindFunctions::const_iterator it = factories.begin(); it != factories.end(); ++it)
-    {
-        std::cout << it->first << ", ";
-    }
+    const auto factories = SoapySDR::Registry::listFindFunctions();
+    for (const auto &it : factories) std::cout << it.first << ", ";
     if (factories.empty()) std::cout << "No factories found!" << std::endl;
     std::cout << std::endl;
     return EXIT_SUCCESS;
@@ -68,13 +62,13 @@ static int findDevices(void)
     std::string argStr;
     if (optarg != NULL) argStr = optarg;
 
-    SoapySDR::KwargsList results = SoapySDR::Device::enumerate(argStr);
+    const auto results = SoapySDR::Device::enumerate(argStr);
     for (size_t i = 0; i < results.size(); i++)
     {
         std::cout << "Found device " << i << std::endl;
-        for (SoapySDR::Kwargs::const_iterator it = results[i].begin(); it != results[i].end(); ++it)
+        for (const auto &it : results[i])
         {
-            std::cout << "  " << it->first << " = " << it->second << std::endl;
+            std::cout << "  " << it.first << " = " << it.second << std::endl;
         }
         std::cout << std::endl;
     }
@@ -98,13 +92,12 @@ static int makeDevice(void)
     std::cout << "Make device " << argStr << std::endl;
     try
     {
-        SoapySDR::Device *device = SoapySDR::Device::make(argStr);
+        auto device = SoapySDR::Device::make(argStr);
         std::cout << "  driver=" << device->getDriverKey() << std::endl;
         std::cout << "  hardware=" << device->getHardwareKey() << std::endl;
-        SoapySDR::Kwargs info = device->getHardwareInfo();
-        for (SoapySDR::Kwargs::const_iterator it = info.begin(); it != info.end(); ++it)
+        for (const auto &it : device->getHardwareInfo())
         {
-            std::cout << "  " << it->first << "=" << it->second << std::endl;
+            std::cout << "  " << it.first << "=" << it.second << std::endl;
         }
         SoapySDR::Device::unmake(device);
     }
@@ -128,7 +121,7 @@ static int probeDevice(void)
     std::cout << "Probe device " << argStr << std::endl;
     try
     {
-        SoapySDR::Device *device = SoapySDR::Device::make(argStr);
+        auto device = SoapySDR::Device::make(argStr);
         std::cout << SoapySDRDeviceProbe(device) << std::endl;
         SoapySDR::Device::unmake(device);
     }
@@ -154,7 +147,7 @@ static int checkDriver(void)
     std::cout << "done" << std::endl;
 
     std::cout << "Checking driver '" << driverName << "'... " << std::flush;
-    const SoapySDR::FindFunctions factories = SoapySDR::Registry::listFindFunctions();
+    const auto factories = SoapySDR::Registry::listFindFunctions();
 
     if (factories.find(driverName) == factories.end())
     {

--- a/cmake/SoapySDRConfig.cmake
+++ b/cmake/SoapySDRConfig.cmake
@@ -63,7 +63,17 @@ endif()
 ########################################################################
 # Helpful compiler flags
 ########################################################################
+
+#C++11 is a required language feature for this project
+set(CMAKE_CXX_STANDARD 11)
+
 if(CMAKE_COMPILER_IS_GNUCXX)
+
+    #enable C++11 on older versions of cmake
+    if (CMAKE_VERSION VERSION_LESS "3.1")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    endif()
+
     #force a compile-time error when symbols are missing
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
@@ -84,11 +94,24 @@ if(APPLE)
 endif()
 
 if(MSVC)
+    #C++11 is a required language feature for this project
+    if (${MSVC_VERSION} LESS 1700)
+        message(FATAL_ERROR "the build requires MSVC 2012 or newer for C++11 support")
+    endif()
+
+    #we always want to use multiple cores for compilation
+    add_compile_options(/MP)
+
     #suppress the following warnings which are commonly caused by project headers
     add_compile_options(/wd4251) #disable 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
     add_compile_options(/wd4503) #'identifier' : decorated name length exceeded, name was truncated
 
+    #projects should be cross-platform and standard stl functions should work
     add_definitions(-DNOMINMAX) #enables std::min and std::max
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+    add_compile_options(-stdlib=libc++)
 endif()
 
 ########################################################################

--- a/include/SoapySDR/Device.h
+++ b/include/SoapySDR/Device.h
@@ -62,9 +62,6 @@ SOAPY_SDR_API SoapySDRKwargs *SoapySDRDevice_enumerateStrArgs(const char *args, 
  * with the same arguments will produce the same device.
  * For every call to make, there should be a matched call to unmake.
  *
- * \note This call is not thread safe. Implementations calling into make
- * from multiple threads should protect this call with a mutex.
- *
  * \param args device construction key/value argument map
  * \return a pointer to a new Device object
  */
@@ -75,9 +72,6 @@ SOAPY_SDR_API SoapySDRDevice *SoapySDRDevice_make(const SoapySDRKwargs *args);
  * The device pointer will be stored in a table so subsequent calls
  * with the same arguments will produce the same device.
  * For every call to make, there should be a matched call to unmake.
- *
- * \note This call is not thread safe. Implementations calling into make
- * from multiple threads should protect this call with a mutex.
  *
  * \param args a markup string of key/value arguments
  * \return a pointer to a new Device object

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -56,9 +56,6 @@ public:
      * with the same arguments will produce the same device.
      * For every call to make, there should be a matched call to unmake.
      *
-     * \note This call is not thread safe. Implementations calling into make
-     * from multiple threads should protect this call with a mutex.
-     *
      * \param args device construction key/value argument map
      * \return a pointer to a new Device object
      */
@@ -69,9 +66,6 @@ public:
      * The device pointer will be stored in a table so subsequent calls
      * with the same arguments will produce the same device.
      * For every call to make, there should be a matched call to unmake.
-     *
-     * \note This call is not thread safe. Implementations calling into make
-     * from multiple threads should protect this call with a mutex.
      *
      * \param args a markup string of key/value arguments
      * \return a pointer to a new Device object

--- a/lib/Device.cpp
+++ b/lib/Device.cpp
@@ -79,7 +79,7 @@ SoapySDR::ArgInfoList SoapySDR::Device::getStreamArgsInfo(const int, const size_
 
 SoapySDR::Stream *SoapySDR::Device::setupStream(const int, const std::string &, const std::vector<size_t> &, const Kwargs &)
 {
-    return NULL;
+    return nullptr;
 }
 
 void SoapySDR::Device::closeStream(Stream *)

--- a/lib/Device.cpp
+++ b/lib/Device.cpp
@@ -244,12 +244,12 @@ bool SoapySDR::Device::getGainMode(const int, const size_t) const
 void SoapySDR::Device::setGain(const int dir, const size_t channel, double gain)
 {
     //algorithm to distribute overall gain (TX gets BB first, RX gets RF first)
-    std::vector<std::string> names = this->listGains(dir, channel);
+    const auto names = this->listGains(dir, channel);
     if (dir == SOAPY_SDR_TX)
     {
         for (int i = names.size()-1; i >= 0; i--)
         {
-            const SoapySDR::Range r = this->getGainRange(dir, channel, names[i]);
+            const auto r = this->getGainRange(dir, channel, names[i]);
             const double g = std::min(gain, r.maximum()-r.minimum());
             this->setGain(dir, channel, names[i], g+r.minimum());
             gain -= this->getGain(dir, channel, names[i])-r.minimum();
@@ -259,7 +259,7 @@ void SoapySDR::Device::setGain(const int dir, const size_t channel, double gain)
     {
         for (size_t i = 0; i < names.size(); i++)
         {
-            const SoapySDR::Range r = this->getGainRange(dir, channel, names[i]);
+            const auto r = this->getGainRange(dir, channel, names[i]);
             const double g = std::min(gain, r.maximum()-r.minimum());
             this->setGain(dir, channel, names[i], g+r.minimum());
             gain -= this->getGain(dir, channel, names[i])-r.minimum();
@@ -276,11 +276,10 @@ double SoapySDR::Device::getGain(const int dir, const size_t channel) const
 {
     //algorithm to return an overall gain (summing each normalized gain)
     double gain = 0.0;
-    std::vector<std::string> names = this->listGains(dir, channel);
-    for (size_t i = 0; i < names.size(); i++)
+    for (const auto &name : this->listGains(dir, channel))
     {
-        const SoapySDR::Range r = this->getGainRange(dir, channel, names[i]);
-        gain += this->getGain(dir, channel, names[i])-r.minimum();
+        const auto r = this->getGainRange(dir, channel, name);
+        gain += this->getGain(dir, channel, name)-r.minimum();
     }
     return gain;
 }
@@ -299,10 +298,9 @@ SoapySDR::Range SoapySDR::Device::getGainRange(const int dir, const size_t chann
 {
     //algorithm to return an overall gain range (use 0 to max possible on each element)
     double gain = 0.0;
-    std::vector<std::string> names = this->listGains(dir, channel);
-    for (size_t i = 0; i < names.size(); i++)
+    for (const auto &name : this->listGains(dir, channel))
     {
-        const SoapySDR::Range r = this->getGainRange(dir, channel, names[i]);
+        const auto r = this->getGainRange(dir, channel, name);
         gain += r.maximum()-r.minimum();
     }
     return SoapySDR::Range(0.0, gain);
@@ -313,7 +311,7 @@ SoapySDR::Range SoapySDR::Device::getGainRange(const int dir, const size_t chann
  ******************************************************************/
 void SoapySDR::Device::setFrequency(const int dir, const size_t chan, double freq, const Kwargs &args)
 {
-    const std::vector<std::string> comps = this->listFrequencies(dir, chan);
+    const auto comps = this->listFrequencies(dir, chan);
     if (comps.empty()) return;
 
     //optional offset, use on RF element when specified
@@ -361,10 +359,9 @@ double SoapySDR::Device::getFrequency(const int dir, const size_t chan) const
     double freq = 0.0;
 
     //overall frequency is the sum of components
-    const std::vector<std::string> comps = this->listFrequencies(dir, chan);
-    for (size_t comp_i = 0; comp_i < comps.size(); comp_i++)
+    for (const auto &comp : this->listFrequencies(dir, chan))
     {
-        const std::string &name = comps[comp_i];
+        const std::string &name = comp;
         freq += this->getFrequency(dir, chan, name);
     }
 
@@ -384,11 +381,11 @@ std::vector<std::string> SoapySDR::Device::listFrequencies(const int, const size
 SoapySDR::RangeList SoapySDR::Device::getFrequencyRange(const int dir, const size_t chan) const
 {
     //get a list of tunable components
-    const std::vector<std::string> comps = this->listFrequencies(dir, chan);
+    const auto comps = this->listFrequencies(dir, chan);
     if (comps.empty()) return SoapySDR::RangeList();
 
     //get the range list for the RF component
-    SoapySDR::RangeList ranges = this->getFrequencyRange(dir, chan, comps.front());
+    auto ranges = this->getFrequencyRange(dir, chan, comps.front());
 
     //use bandwidth setting to clip the range
     const double bw = this->getBandwidth(dir, chan);
@@ -396,7 +393,7 @@ SoapySDR::RangeList SoapySDR::Device::getFrequencyRange(const int dir, const siz
     //add to the range list given subsequent components
     for (size_t comp_i = 1; comp_i < comps.size(); comp_i++)
     {
-        SoapySDR::RangeList subRange = this->getFrequencyRange(dir, chan, comps[comp_i]);
+        const auto subRange = this->getFrequencyRange(dir, chan, comps[comp_i]);
         if (subRange.empty()) continue;
 
         double subRangeLow = subRange.front().minimum();
@@ -426,7 +423,7 @@ SoapySDR::ArgInfoList SoapySDR::Device::getFrequencyArgsInfo(const int dir, cons
 {
     SoapySDR::ArgInfoList args;
 
-    const std::vector<std::string> comps = this->listFrequencies(dir, chan);
+    const auto comps = this->listFrequencies(dir, chan);
 
     if (comps.size() < 2) return args; //no tuning options with single components
 
@@ -505,10 +502,8 @@ SoapySDR::RangeList SoapySDR::Device::getBandwidthRange(const int direction, con
 {
     SoapySDR::RangeList ranges;
     //call into the older deprecated listBandwidths() call
-    const std::vector<double> bws = this->listBandwidths(direction, channel);
-    for (size_t i = 0; i < bws.size(); i++)
+    for (auto &bw : this->listBandwidths(direction, channel))
     {
-        const double bw = bws.at(i);
         ranges.push_back(SoapySDR::Range(bw, bw));
     }
     return ranges;

--- a/lib/Factory.cpp
+++ b/lib/Factory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Device.hpp>
@@ -28,26 +28,25 @@ SoapySDR::KwargsList SoapySDR::Device::enumerate(const Kwargs &args)
 {
     loadModules();
     SoapySDR::KwargsList results;
-    const FindFunctions findFunctions = Registry::listFindFunctions();
-    for (FindFunctions::const_iterator it = findFunctions.begin(); it != findFunctions.end(); ++it)
+    for (const auto &it : Registry::listFindFunctions())
     {
-        if (args.count("driver") != 0 and args.at("driver") != it->first) continue;
+        if (args.count("driver") != 0 and args.at("driver") != it.first) continue;
         try
         {
-            SoapySDR::KwargsList results0 = it->second(args);
+            SoapySDR::KwargsList results0 = it.second(args);
             for (size_t i = 0; i < results0.size(); i++)
             {
-                results0[i]["driver"] = it->first;
+                results0[i]["driver"] = it.first;
                 results.push_back(results0[i]);
             }
         }
         catch (const std::exception &ex)
         {
-            std::cerr << "SoapySDR::Device::enumerate(" << it->first << ") " << ex.what() << std::endl;
+            std::cerr << "SoapySDR::Device::enumerate(" << it.first << ") " << ex.what() << std::endl;
         }
         catch (...)
         {
-            std::cerr << "SoapySDR::Device::enumerate(" << it->first << ") " << "unknown error" << std::endl;
+            std::cerr << "SoapySDR::Device::enumerate(" << it.first << ") " << "unknown error" << std::endl;
         }
     }
     return results;
@@ -121,17 +120,16 @@ SoapySDR::Device* SoapySDR::Device::make(const Kwargs &args_)
         }
 
         //load the enumeration args with missing keys from the make argument
-        for (Kwargs::const_iterator it = args_.begin(); it != args_.end(); ++it)
+        for (const auto &it : args_)
         {
-            if (args.count(it->first) == 0) args[it->first] = it->second;
+            if (args.count(it.first) == 0) args[it.first] = it.second;
         }
 
         //loop through make functions and call on module match
-        MakeFunctions makeFunctions = Registry::listMakeFunctions();
-        for (MakeFunctions::const_iterator it = makeFunctions.begin(); it != makeFunctions.end(); ++it)
+        for (const auto &it : Registry::listMakeFunctions())
         {
-            if (args.count("driver") != 0 and args.at("driver") != it->first) continue;
-            device = it->second(args);
+            if (args.count("driver") != 0 and args.at("driver") != it.first) continue;
+            device = it.second(args);
             break;
         }
     }
@@ -165,7 +163,7 @@ void SoapySDR::Device::unmake(Device *device)
         delete device;
 
         //cleanup the argument to device table
-        for (DeviceTable::iterator it = getDeviceTable().begin(); it != getDeviceTable().end(); ++it)
+        for (auto it = getDeviceTable().begin(); it != getDeviceTable().end(); ++it)
         {
             if (it->second == device)
             {

--- a/lib/Factory.cpp
+++ b/lib/Factory.cpp
@@ -113,7 +113,7 @@ SoapySDR::Device* SoapySDR::Device::make(const Kwargs &args_)
 
     loadModules();
     Kwargs args = args_;
-    Device *device = NULL;
+    Device *device = nullptr;
 
     //check the device table for an already allocated device
     if (getDeviceTable().count(args_) != 0 and getDeviceCounts().count(getDeviceTable().at(args_)) != 0)
@@ -145,7 +145,7 @@ SoapySDR::Device* SoapySDR::Device::make(const Kwargs &args_)
         }
     }
 
-    if (device == NULL) throw std::runtime_error("SoapySDR::Device::make() no match");
+    if (device == nullptr) throw std::runtime_error("SoapySDR::Device::make() no match");
 
     //store into the table
     getDeviceTable()[args_] = device;

--- a/lib/Modules.in.cpp
+++ b/lib/Modules.in.cpp
@@ -274,17 +274,16 @@ void SoapySDR::loadModules(void)
     loaded = true;
     lateLoadNullDevice();
 
-    const std::vector<std::string> paths = listModules();
+    const auto paths = listModules();
     for (size_t i = 0; i < paths.size(); i++)
     {
         if (getModuleHandles().count(paths[i]) != 0) continue; //was manually loaded
         const std::string errorMsg = loadModule(paths[i]);
         if (not errorMsg.empty()) SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::loadModule(%s)\n  %s", paths[i].c_str(), errorMsg.c_str());
-        const SoapySDR::Kwargs loaderResults = SoapySDR::getLoaderResult(paths[i]);
-        for (SoapySDR::Kwargs::const_iterator it = loaderResults.begin(); it != loaderResults.end(); ++it)
+        for (const auto &it : SoapySDR::getLoaderResult(paths[i]))
         {
-            if (it->second.empty()) continue;
-            SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::loadModule(%s)\n  %s", paths[i].c_str(), it->second.c_str());
+            if (it.second.empty()) continue;
+            SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::loadModule(%s)\n  %s", paths[i].c_str(), it.second.c_str());
         }
     }
 }

--- a/lib/Registry.cpp
+++ b/lib/Registry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Registry.hpp>
@@ -72,9 +72,9 @@ SoapySDR::Registry::~Registry(void)
 SoapySDR::FindFunctions SoapySDR::Registry::listFindFunctions(void)
 {
     FindFunctions functions;
-    for (FunctionTable::const_iterator it = getFunctionTable().begin(); it != getFunctionTable().end(); ++it)
+    for (const auto &it : getFunctionTable())
     {
-        functions[it->first] = it->second.find;
+        functions[it.first] = it.second.find;
     }
     return functions;
 }
@@ -82,9 +82,9 @@ SoapySDR::FindFunctions SoapySDR::Registry::listFindFunctions(void)
 SoapySDR::MakeFunctions SoapySDR::Registry::listMakeFunctions(void)
 {
     MakeFunctions functions;
-    for (FunctionTable::const_iterator it = getFunctionTable().begin(); it != getFunctionTable().end(); ++it)
+    for (const auto &it : getFunctionTable())
     {
-        functions[it->first] = it->second.make;
+        functions[it.first] = it.second.make;
     }
     return functions;
 }

--- a/lib/TypeHelpers.hpp
+++ b/lib/TypeHelpers.hpp
@@ -63,9 +63,9 @@ static inline SoapySDRKwargs toKwargs(const SoapySDR::Kwargs &args)
 {
     SoapySDRKwargs out;
     std::memset(&out, 0, sizeof(out));
-    for (SoapySDR::Kwargs::const_iterator it = args.begin(); it != args.end(); ++it)
+    for (const auto &it : args)
     {
-        SoapySDRKwargs_set(&out, it->first.c_str(), it->second.c_str());
+        SoapySDRKwargs_set(&out, it.first.c_str(), it.second.c_str());
     }
     return out;
 }

--- a/python/SoapySDR.i
+++ b/python/SoapySDR.i
@@ -121,8 +121,6 @@
 
 //global factory lock support
 %pythoncode %{
-import threading
-device_factory_lock = threading.Lock()
 
 __all__ = list()
 for key in sorted(globals().keys()):
@@ -136,13 +134,7 @@ for key in sorted(globals().keys()):
 _Device = Device
 class Device(Device):
     def __new__(cls, *args, **kwargs):
-        with device_factory_lock:
-            return cls.make(*args, **kwargs)
-
-    @staticmethod
-    def enumerate(*args):
-        with device_factory_lock:
-            return _Device.enumerate(*args)
+        return cls.make(*args, **kwargs)
 
 def extractBuffPointer(buff):
     if hasattr(buff, '__array_interface__'): return buff.__array_interface__['data'][0]
@@ -184,8 +176,7 @@ def extractBuffPointer(buff):
     %{
         #call unmake from custom deleter
         def __del__(self):
-            with device_factory_lock:
-                Device.unmake(self)
+            Device.unmake(self)
 
         def __str__(self):
             return "%s:%s"%(self.getDriverKey(), self.getHardwareKey())


### PR DESCRIPTION
* use C++11 internally to simplify code
* use std::mutex inside factory calls
* update API docs about thread safety
* remove python factory mutex (in core library now)
* provide C++11 flags to submodules
* resolves #74 