### PR TITLE
Change SoapySDR logger to only use stderr by default

### DIFF
--- a/include/SoapySDR/Logger.h
+++ b/include/SoapySDR/Logger.h
@@ -3,7 +3,7 @@
 ///
 /// Logger API for SoapySDR devices.
 /// Implementations should use the logger rather than stdio.
-/// The default log handler prints to the stdout and stderr.
+/// The default log handler prints to stderr.
 ///
 /// \copyright
 /// Copyright (c) 2014-2015 Josh Blum

--- a/include/SoapySDR/Logger.hpp
+++ b/include/SoapySDR/Logger.hpp
@@ -3,7 +3,7 @@
 ///
 /// Logger API for SoapySDR devices.
 /// Implementations should use the logger rather than stdio.
-/// The default log handler prints to the stdout and stderr.
+/// The default log handler prints to stderr.
 ///
 /// \copyright
 /// Copyright (c) 2014-2015 Josh Blum

--- a/lib/LoggerC.cpp
+++ b/lib/LoggerC.cpp
@@ -71,10 +71,10 @@ void defaultLogHandler(const SoapySDRLogLevel logLevel, const char *message)
     case SOAPY_SDR_CRITICAL: fprintf(stderr, ANSI_COLOR_BOLD ANSI_COLOR_RED "[CRITICAL] %s" ANSI_COLOR_RESET "\n", message); break;
     case SOAPY_SDR_ERROR:    fprintf(stderr, ANSI_COLOR_BOLD ANSI_COLOR_RED "[ERROR] %s" ANSI_COLOR_RESET "\n", message); break;
     case SOAPY_SDR_WARNING:  fprintf(stderr, ANSI_COLOR_BOLD ANSI_COLOR_YELLOW "[WARNING] %s" ANSI_COLOR_RESET "\n", message); break;
-    case SOAPY_SDR_NOTICE:   fprintf(stdout, ANSI_COLOR_GREEN "[NOTICE] %s" ANSI_COLOR_RESET "\n", message); break;
-    case SOAPY_SDR_INFO:     fprintf(stdout, "[INFO] %s\n", message); break;
-    case SOAPY_SDR_DEBUG:    fprintf(stdout, "[DEBUG] %s\n", message); break;
-    case SOAPY_SDR_TRACE:    fprintf(stdout, "[TRACE] %s\n", message); break;
+    case SOAPY_SDR_NOTICE:   fprintf(stderr, ANSI_COLOR_GREEN "[NOTICE] %s" ANSI_COLOR_RESET "\n", message); break;
+    case SOAPY_SDR_INFO:     fprintf(stderr, "[INFO] %s\n", message); break;
+    case SOAPY_SDR_DEBUG:    fprintf(stderr, "[DEBUG] %s\n", message); break;
+    case SOAPY_SDR_TRACE:    fprintf(stderr, "[TRACE] %s\n", message); break;
     case SOAPY_SDR_SSI:      fputs(message, stderr); fflush(stderr); break;
     }
 }


### PR DESCRIPTION
By only logging to stderr by default, command-line tools can be more easily written using SoapySDR which write their own output to stdout. Otherwise, stdout becomes a mixture of SoapySDR logging and the tool's output.

Consistently logging to stderr also makes redirecting logging more straightforward, `./foo 2>/tmp/log` will save all of the logging to /tmp/log, instead of only the higher severity messages, as the lower severity messages go to stdout. `./foo 2>/tmp/log-stderr >/tmp/log-stdout` would capture both, but then the high and low severity messages would be separated, necessitating something like `./foo >/tmp/log 2>&1` to combine both stdout and stderr into one file. This gets 
complicated quickly, my 2¢ I think it's better to at least by default log messages only to [stderr](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_.28stderr.29), as is common with other Unix utilities/libraries.

--

This frees up tools to use stdout for their own purposes. How I ran into this: https://github.com/rxseger/rx_tools/pull/11#issuecomment-233168397 - long story short, my tool was writing 16-bit audio output to stdout, a seemingly-unrelated change caused SoapySDR to log one additional byte to stdout, shifting the output by 8-bits and causing noise-only audio output.

A possible client-side workaround (another one: overriding the logger, possible but haven't tried that yet), for the record: temporarily redirecting stdout to stderr and back, during initialization - I'll likely keep this for some time since the UHD driver or something also unwelcomely logs "Mac OS; Clang version 7.3.0 (clang-703.0.31); Boost_106000; UHD_003.009.004-0-unknown" to stdout:

```
	int tmp_stdout = dup(STDOUT_FILENO);
 	dup2(STDERR_FILENO, STDOUT_FILENO);

 	// … call SoapySDRDevice_enumerate and SoapySDRDevice_setupStream …

	dup2(tmp_stdout, STDOUT_FILENO);
```

but this PR removes the SoapySDR_Log output on stdout, instead writing to stderr, at all levels.