### PR TITLE
debian: allow any swig >= 2.0.12

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Josh Blum <josh@pothosware.com>
 Build-Depends:
     debhelper (>= 9.0.0),
     cmake (>= 2.8.7),
-    swig2.0,
+    swig (>= 2.0.0),
     python,
     python-dev,
     python3,


### PR DESCRIPTION
Works fine with both swig 2 and 3 (from debian testing).