### PR TITLE
Added SoapySDR_getLibVersion() and SOAPY_SDR_API_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ enable_testing()
 # gather version information
 # packagers may specify -DSOAPY_SDR_EXTVER="foo" to replace the git hash
 ########################################################################
-set(SOAPY_SDR_LIBVER "0.5.0")
+set(SOAPY_SDR_LIBVER "0.5.1")
 
 if (NOT SOAPY_SDR_EXTVER)
     include(${PROJECT_SOURCE_DIR}/cmake/GetGitRevisionDescription.cmake)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the SoapySDR project.
 Release 0.5.1 (pending)
 ==========================
 
+- Added SoapySDR_getLibVersion() and SOAPY_SDR_API_VERSION
 - debian allow any swig >= 2.0.0 using the swig meta-package
 - Only use stderr in the default logger for command line tools
 - ABI-specific modules directory for multi-version install

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -34,6 +34,7 @@ static int printHelp(void)
  **********************************************************************/
 static int printInfo(void)
 {
+    std::cout << "Lib Version: v" << SoapySDR::getLibVersion() << std::endl;
     std::cout << "API Version: v" << SoapySDR::getAPIVersion() << std::endl;
     std::cout << "ABI Version: v" << SoapySDR::getABIVersion() << std::endl;
     std::cout << "Install root: " << SoapySDR::getRootPath() << std::endl;

--- a/include/SoapySDR/Version.h
+++ b/include/SoapySDR/Version.h
@@ -13,7 +13,27 @@
 #include <SoapySDR/Config.h>
 
 /*!
+ * API version number which can be used as a preprocessor check.
+ * The format of the version number is encoded as follows:
+ * <b>(major << 24) | (minor << 16) | (16 bit increment)</b>.
+ * Where the increment can be used to indicate implementation
+ * changes, fixes, or API additions within a minor release series.
+ *
+ * The macro is typically used in an application as follows:
+ * \code
+ * #if defined(SOAPY_SDR_API_VERSION) && (SOAPY_SDR_API_VERSION >= 0x00001234)
+ * // Use a newer feature from the SoapySDR library API
+ * #endif
+ * \endcode
+ */
+#define SOAPY_SDR_API_VERSION 0x00050001
+
+/*!
  * ABI Version Information - incremented when the ABI is changed.
+ * The ABI version format is <b>major.minor-bump</b>. The <i>major.minor</i>
+ * comes from the in-progress library version when the change was made,
+ * and <i>bump</i> signifies a change to the ABI during library development.
+ * The ABI should remain constant across patch releases of the library.
  */
 #define SOAPY_SDR_ABI_VERSION "0.5-2"
 
@@ -107,15 +127,28 @@ extern "C" {
 #endif
 
 /*!
- * Query the API version string.
+ * Get the SoapySDR library API version as a string.
+ * The format of the version string is <b>major.minor.increment</b>,
+ * where the digits are taken directly from <b>SOAPY_SDR_API_VERSION</b>.
  */
 SOAPY_SDR_API const char *SoapySDR_getAPIVersion(void);
 
 /*!
- * Get the ABI version string.
- * This is the SOAPY_SDR_ABI_VERSION that the library was built against.
+ * Get the ABI version string that the library was built against.
+ * A client can compare <b>SOAPY_SDR_ABI_VERSION</b> to getABIVersion()
+ * to check for ABI incompatibility before using the library.
+ * If the values are not equal then the client code was
+ * compiled against a different ABI than the library.
  */
 SOAPY_SDR_API const char *SoapySDR_getABIVersion(void);
+
+/*!
+ * Get the library version and build information string.
+ * The format of the version string is <b>major.minor.patch-buildInfo</b>.
+ * This function is commonly used to identify the software back-end
+ * to the user for command-line utilities and graphical applications.
+ */
+SOAPY_SDR_API const char *SoapySDR_getLibVersion(void);
 
 #ifdef __cplusplus
 }

--- a/include/SoapySDR/Version.hpp
+++ b/include/SoapySDR/Version.hpp
@@ -4,7 +4,7 @@
 /// Utility functions to query version information.
 ///
 /// \copyright
-/// Copyright (c) 2014-2014 Josh Blum
+/// Copyright (c) 2014-2016 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -16,13 +16,28 @@
 namespace SoapySDR
 {
 
-//! Query the API version string
+/*!
+ * Get the SoapySDR library API version as a string.
+ * The format of the version string is <b>major.minor.increment</b>,
+ * where the digits are taken directly from <b>SOAPY_SDR_API_VERSION</b>.
+ */
 SOAPY_SDR_API std::string getAPIVersion(void);
 
 /*!
- * Get the ABI version string.
- * This is the SOAPY_SDR_ABI_VERSION that the library was built against.
+ * Get the ABI version string that the library was built against.
+ * A client can compare <b>SOAPY_SDR_ABI_VERSION</b> to getABIVersion()
+ * to check for ABI incompatibility before using the library.
+ * If the values are not equal then the client code was
+ * compiled against a different ABI than the library.
  */
 SOAPY_SDR_API std::string getABIVersion(void);
+
+/*!
+ * Get the library version and build information string.
+ * The format of the version string is <b>major.minor.patch-buildInfo</b>.
+ * This function is commonly used to identify the software back-end
+ * to the user for command-line utilities and graphical applications.
+ */
+SOAPY_SDR_API std::string getLibVersion(void);
 
 }

--- a/lib/Version.in.cpp
+++ b/lib/Version.in.cpp
@@ -1,14 +1,24 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Version.hpp>
+#include <sstream>
 
 std::string SoapySDR::getAPIVersion(void)
 {
-    return "@SOAPY_SDR_VERSION@";
+    std::stringstream ss;
+    ss << int((SOAPY_SDR_API_VERSION >> 24) & 0xf) << "."
+       << int((SOAPY_SDR_API_VERSION >> 16) & 0xf) << "."
+       << int((SOAPY_SDR_API_VERSION >> 0) & 0xff);
+    return ss.str();
 }
 
 std::string SoapySDR::getABIVersion(void)
 {
     return SOAPY_SDR_ABI_VERSION;
+}
+
+std::string SoapySDR::getLibVersion(void)
+{
+    return "@SOAPY_SDR_VERSION@";
 }

--- a/lib/VersionC.cpp
+++ b/lib/VersionC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Version.hpp>
@@ -15,6 +15,12 @@ const char *SoapySDR_getABIVersion(void)
 {
     static const std::string abi = SoapySDR::getABIVersion();
     return abi.c_str();
+}
+
+const char *SoapySDR_getLibVersion(void)
+{
+    static const std::string lib = SoapySDR::getLibVersion();
+    return lib.c_str();
 }
 
 }


### PR DESCRIPTION
* added a getLibVersion() to query the library version with build info
* added SOAPY_SDR_API_VERSION for compile time checks
* getAPIVersion() now queries a string version of SOAPY_SDR_API_VERSION
* added general documentation about version numbering

@andreasbombe let me know if this satisfies the issue, I will go with this for 0.5.1 then.