### PR TITLE
Additional try/catch for C API

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,10 @@
 This this the changelog file for the SoapySDR project.
 
+Release 0.5.3 (pending)
+==========================
+
+- Additional try/catch blocks for C API wrapper safety
+
 Release 0.5.2 (2016-08-18)
 ==========================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ branches:
   # whitelist
   only:
     - master
+    - maint
 
 # dependencies for python bindings
 # disabled because of link issues on VM

--- a/include/SoapySDR/Device.h
+++ b/include/SoapySDR/Device.h
@@ -31,10 +31,20 @@ typedef struct SoapySDRDevice SoapySDRDevice;
 typedef struct SoapySDRStream SoapySDRStream;
 
 /*!
+ * Get the last status code after a Device API call.
+ * The status code is cleared on entry to each Device call.
+ * When an device API call throws, the C bindings catch
+ * the exception, and set a non-zero last status code.
+ * Use lastStatus() to determine success/failure for
+ * Device calls without integer status return codes.
+ */
+SOAPY_SDR_API int SoapySDRDevice_lastStatus(void);
+
+/*!
  * Get the last error message after a device call fails.
  * When an device API call throws, the C bindings catch
  * the exception, store its message in thread-safe storage,
- * and return a non-zero status code to inidicate failure.
+ * and return a non-zero status code to indicate failure.
  * Use lastError() to access the exception's error message.
  */
 SOAPY_SDR_API const char *SoapySDRDevice_lastError(void);

--- a/include/SoapySDR/Version.h
+++ b/include/SoapySDR/Version.h
@@ -26,7 +26,7 @@
  * #endif
  * \endcode
  */
-#define SOAPY_SDR_API_VERSION 0x00050001
+#define SOAPY_SDR_API_VERSION 0x00050002
 
 /*!
  * ABI Version Information - incremented when the ABI is changed.

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -94,7 +94,9 @@ SoapySDRKwargs SoapySDRDevice_getChannelInfo(const SoapySDRDevice *device, const
 
 bool SoapySDRDevice_getFullDuplex(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getFullDuplex(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 /*******************************************************************
@@ -132,12 +134,16 @@ int SoapySDRDevice_setupStream(SoapySDRDevice *device, SoapySDRStream **stream, 
 
 void SoapySDRDevice_closeStream(SoapySDRDevice *device, SoapySDRStream *stream)
 {
+    __SOAPY_SDR_C_TRY
     return device->closeStream(reinterpret_cast<SoapySDR::Stream *>(stream));
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 size_t SoapySDRDevice_getStreamMTU(const SoapySDRDevice *device, SoapySDRStream *stream)
 {
+    __SOAPY_SDR_C_TRY
     return device->getStreamMTU(reinterpret_cast<SoapySDR::Stream *>(stream));
+    __SOAPY_SDR_C_CATCH_RET(std::string::npos);
 }
 
 int SoapySDRDevice_activateStream(SoapySDRDevice *device,
@@ -146,7 +152,9 @@ int SoapySDRDevice_activateStream(SoapySDRDevice *device,
     const long long timeNs,
     const size_t numElems)
 {
+    __SOAPY_SDR_C_TRY
     return device->activateStream(reinterpret_cast<SoapySDR::Stream *>(stream), flags, timeNs, numElems);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
 
 int SoapySDRDevice_deactivateStream(SoapySDRDevice *device,
@@ -154,36 +162,47 @@ int SoapySDRDevice_deactivateStream(SoapySDRDevice *device,
     const int flags,
     const long long timeNs)
 {
+    __SOAPY_SDR_C_TRY
     return device->deactivateStream(reinterpret_cast<SoapySDR::Stream *>(stream), flags, timeNs);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
 
 int SoapySDRDevice_readStream(SoapySDRDevice *device, SoapySDRStream *stream, void * const *buffs, const size_t numElems, int *flags, long long *timeNs, const long timeoutUs)
 {
+    __SOAPY_SDR_C_TRY
     return device->readStream(reinterpret_cast<SoapySDR::Stream *>(stream), buffs, numElems, *flags, *timeNs, timeoutUs);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
 
 int SoapySDRDevice_writeStream(SoapySDRDevice *device, SoapySDRStream *stream, const void * const *buffs, const size_t numElems, int *flags, const long long timeNs, const long timeoutUs)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeStream(reinterpret_cast<SoapySDR::Stream *>(stream), buffs, numElems, *flags, timeNs, timeoutUs);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
 
 int SoapySDRDevice_readStreamStatus(SoapySDRDevice *device, SoapySDRStream *stream, size_t *chanMask, int *flags, long long *timeNs, const long timeoutUs)
 {
+    __SOAPY_SDR_C_TRY
     return device->readStreamStatus(reinterpret_cast<SoapySDR::Stream *>(stream), *chanMask, *flags, *timeNs, timeoutUs);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
-
 
 /*******************************************************************
  * Direct buffer access API
  ******************************************************************/
 size_t SoapySDRDevice_getNumDirectAccessBuffers(SoapySDRDevice *device, SoapySDRStream *stream)
 {
+    __SOAPY_SDR_C_TRY
     return device->getNumDirectAccessBuffers(reinterpret_cast<SoapySDR::Stream *>(stream));
+    __SOAPY_SDR_C_CATCH_RET(std::string::npos);
 }
 
 int SoapySDRDevice_getDirectAccessBufferAddrs(SoapySDRDevice *device, SoapySDRStream *stream, const size_t handle, void **buffs)
 {
+    __SOAPY_SDR_C_TRY
     return device->getDirectAccessBufferAddrs(reinterpret_cast<SoapySDR::Stream *>(stream), handle, buffs);
+    __SOAPY_SDR_C_CATCH
 }
 
 int SoapySDRDevice_acquireReadBuffer(SoapySDRDevice *device,
@@ -194,14 +213,18 @@ int SoapySDRDevice_acquireReadBuffer(SoapySDRDevice *device,
     long long *timeNs,
     const long timeoutUs)
 {
+    __SOAPY_SDR_C_TRY
     return device->acquireReadBuffer(reinterpret_cast<SoapySDR::Stream *>(stream), *handle, buffs, *flags, *timeNs, timeoutUs);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
 
 void SoapySDRDevice_releaseReadBuffer(SoapySDRDevice *device,
     SoapySDRStream *stream,
     const size_t handle)
 {
+    __SOAPY_SDR_C_TRY
     return device->releaseReadBuffer(reinterpret_cast<SoapySDR::Stream *>(stream), handle);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 int SoapySDRDevice_acquireWriteBuffer(SoapySDRDevice *device,
@@ -210,7 +233,9 @@ int SoapySDRDevice_acquireWriteBuffer(SoapySDRDevice *device,
     void **buffs,
     const long timeoutUs)
 {
+    __SOAPY_SDR_C_TRY
     return device->acquireWriteBuffer(reinterpret_cast<SoapySDR::Stream *>(stream), *handle, buffs, timeoutUs);
+    __SOAPY_SDR_C_CATCH_RET(SOAPY_SDR_STREAM_ERROR);
 }
 
 void SoapySDRDevice_releaseWriteBuffer(SoapySDRDevice *device,
@@ -220,7 +245,9 @@ void SoapySDRDevice_releaseWriteBuffer(SoapySDRDevice *device,
     int *flags,
     const long long timeNs)
 {
+    __SOAPY_SDR_C_TRY
     return device->releaseWriteBuffer(reinterpret_cast<SoapySDR::Stream *>(stream), handle, numElems, *flags, timeNs);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 /*******************************************************************
@@ -228,7 +255,9 @@ void SoapySDRDevice_releaseWriteBuffer(SoapySDRDevice *device,
  ******************************************************************/
 char **SoapySDRDevice_listAntennas(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listAntennas(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 int SoapySDRDevice_setAntenna(SoapySDRDevice *device, const int direction, const size_t channel, const char *name)
@@ -240,7 +269,9 @@ int SoapySDRDevice_setAntenna(SoapySDRDevice *device, const int direction, const
 
 char *SoapySDRDevice_getAntenna(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getAntenna(direction, channel).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -248,7 +279,9 @@ char *SoapySDRDevice_getAntenna(const SoapySDRDevice *device, const int directio
  ******************************************************************/
 bool SoapySDRDevice_hasDCOffsetMode(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->hasDCOffsetMode(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 int SoapySDRDevice_setDCOffsetMode(SoapySDRDevice *device, const int direction, const size_t channel, const bool automatic)
@@ -260,12 +293,16 @@ int SoapySDRDevice_setDCOffsetMode(SoapySDRDevice *device, const int direction, 
 
 bool SoapySDRDevice_getDCOffsetMode(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getDCOffsetMode(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 bool SoapySDRDevice_hasDCOffset(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->hasDCOffset(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 int SoapySDRDevice_setDCOffset(SoapySDRDevice *device, const int direction, const size_t channel, const double offsetI, const double offsetQ)
@@ -277,14 +314,18 @@ int SoapySDRDevice_setDCOffset(SoapySDRDevice *device, const int direction, cons
 
 void SoapySDRDevice_getDCOffset(const SoapySDRDevice *device, const int direction, const size_t channel, double *offsetI, double *offsetQ)
 {
+    __SOAPY_SDR_C_TRY
     std::complex<double> ret = device->getDCOffset(direction, channel);
     *offsetI = ret.real();
     *offsetQ = ret.imag();
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 bool SoapySDRDevice_hasIQBalance(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->hasIQBalance(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 int SoapySDRDevice_setIQBalance(SoapySDRDevice *device, const int direction, const size_t channel, const double balanceI, const double balanceQ)
@@ -296,9 +337,11 @@ int SoapySDRDevice_setIQBalance(SoapySDRDevice *device, const int direction, con
 
 void SoapySDRDevice_getIQBalance(const SoapySDRDevice *device, const int direction, const size_t channel, double *balanceI, double *balanceQ)
 {
+    __SOAPY_SDR_C_TRY
     std::complex<double> ret = device->getIQBalance(direction, channel);
     *balanceI = ret.real();
     *balanceQ = ret.imag();
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 /*******************************************************************
@@ -306,12 +349,16 @@ void SoapySDRDevice_getIQBalance(const SoapySDRDevice *device, const int directi
  ******************************************************************/
 char **SoapySDRDevice_listGains(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listGains(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 bool SoapySDRDevice_hasGainMode(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->hasGainMode(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 int SoapySDRDevice_setGainMode(SoapySDRDevice *device, const int direction, const size_t channel, const bool automatic)
@@ -323,7 +370,9 @@ int SoapySDRDevice_setGainMode(SoapySDRDevice *device, const int direction, cons
 
 bool SoapySDRDevice_getGainMode(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getGainMode(direction, channel);
+    __SOAPY_SDR_C_CATCH
 }
 
 int SoapySDRDevice_setGain(SoapySDRDevice *device, const int direction, const size_t channel, const double value)

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -46,6 +46,23 @@ const char *SoapySDRDevice_lastError(void)
 }
 
 /*******************************************************************
+ * Error POD types
+ ******************************************************************/
+
+#define SoapySDRVoidRet
+
+static const bool SoapySDRBoolErr = bool(-1);
+
+static const SoapySDRRange SoapySDRRangeNAN = {NAN, NAN};
+
+static SoapySDRArgInfo SoapySDRArgInfoNull(void)
+{
+    SoapySDRArgInfo info;
+    std::memset(&info, 0, sizeof(info));
+    return info;
+}
+
+/*******************************************************************
  * Simple subclass definition for device
  ******************************************************************/
 struct SoapySDRDevice : SoapySDR::Device {};
@@ -111,7 +128,7 @@ bool SoapySDRDevice_getFullDuplex(const SoapySDRDevice *device, const int direct
 {
     __SOAPY_SDR_C_TRY
     return device->getFullDuplex(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 /*******************************************************************
@@ -153,7 +170,7 @@ void SoapySDRDevice_closeStream(SoapySDRDevice *device, SoapySDRStream *stream)
 {
     __SOAPY_SDR_C_TRY
     return device->closeStream(reinterpret_cast<SoapySDR::Stream *>(stream));
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 size_t SoapySDRDevice_getStreamMTU(const SoapySDRDevice *device, SoapySDRStream *stream)
@@ -241,7 +258,7 @@ void SoapySDRDevice_releaseReadBuffer(SoapySDRDevice *device,
 {
     __SOAPY_SDR_C_TRY
     return device->releaseReadBuffer(reinterpret_cast<SoapySDR::Stream *>(stream), handle);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 int SoapySDRDevice_acquireWriteBuffer(SoapySDRDevice *device,
@@ -264,7 +281,7 @@ void SoapySDRDevice_releaseWriteBuffer(SoapySDRDevice *device,
 {
     __SOAPY_SDR_C_TRY
     return device->releaseWriteBuffer(reinterpret_cast<SoapySDR::Stream *>(stream), handle, numElems, *flags, timeNs);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 /*******************************************************************
@@ -299,7 +316,7 @@ bool SoapySDRDevice_hasDCOffsetMode(const SoapySDRDevice *device, const int dire
 {
     __SOAPY_SDR_C_TRY
     return device->hasDCOffsetMode(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 int SoapySDRDevice_setDCOffsetMode(SoapySDRDevice *device, const int direction, const size_t channel, const bool automatic)
@@ -313,14 +330,14 @@ bool SoapySDRDevice_getDCOffsetMode(const SoapySDRDevice *device, const int dire
 {
     __SOAPY_SDR_C_TRY
     return device->getDCOffsetMode(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 bool SoapySDRDevice_hasDCOffset(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
     __SOAPY_SDR_C_TRY
     return device->hasDCOffset(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 int SoapySDRDevice_setDCOffset(SoapySDRDevice *device, const int direction, const size_t channel, const double offsetI, const double offsetQ)
@@ -336,14 +353,14 @@ void SoapySDRDevice_getDCOffset(const SoapySDRDevice *device, const int directio
     std::complex<double> ret = device->getDCOffset(direction, channel);
     *offsetI = ret.real();
     *offsetQ = ret.imag();
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 bool SoapySDRDevice_hasIQBalance(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
     __SOAPY_SDR_C_TRY
     return device->hasIQBalance(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 int SoapySDRDevice_setIQBalance(SoapySDRDevice *device, const int direction, const size_t channel, const double balanceI, const double balanceQ)
@@ -359,7 +376,7 @@ void SoapySDRDevice_getIQBalance(const SoapySDRDevice *device, const int directi
     std::complex<double> ret = device->getIQBalance(direction, channel);
     *balanceI = ret.real();
     *balanceQ = ret.imag();
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 /*******************************************************************
@@ -377,7 +394,7 @@ bool SoapySDRDevice_hasGainMode(const SoapySDRDevice *device, const int directio
 {
     __SOAPY_SDR_C_TRY
     return device->hasGainMode(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 int SoapySDRDevice_setGainMode(SoapySDRDevice *device, const int direction, const size_t channel, const bool automatic)
@@ -391,7 +408,7 @@ bool SoapySDRDevice_getGainMode(const SoapySDRDevice *device, const int directio
 {
     __SOAPY_SDR_C_TRY
     return device->getGainMode(direction, channel);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 int SoapySDRDevice_setGain(SoapySDRDevice *device, const int direction, const size_t channel, const double value)
@@ -421,8 +438,6 @@ double SoapySDRDevice_getGainElement(const SoapySDRDevice *device, const int dir
     return device->getGain(direction, channel, name);
     __SOAPY_SDR_C_CATCH_RET(NAN);
 }
-
-static const SoapySDRRange SoapySDRRangeNAN = {NAN, NAN};
 
 SoapySDRRange SoapySDRDevice_getGainRange(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
@@ -636,7 +651,7 @@ bool SoapySDRDevice_hasHardwareTime(const SoapySDRDevice *device, const char *wh
 {
     __SOAPY_SDR_C_TRY
     return device->hasHardwareTime(what);
-    __SOAPY_SDR_C_CATCH
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRBoolErr);
 }
 
 long long SoapySDRDevice_getHardwareTime(const SoapySDRDevice *device, const char *what)
@@ -650,14 +665,14 @@ void SoapySDRDevice_setHardwareTime(SoapySDRDevice *device, const long long time
 {
     __SOAPY_SDR_C_TRY
     device->setHardwareTime(timeNs, what);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 void SoapySDRDevice_setCommandTime(SoapySDRDevice *device, const long long timeNs, const char *what)
 {
     __SOAPY_SDR_C_TRY
     device->setCommandTime(timeNs, what);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 /*******************************************************************
@@ -669,13 +684,6 @@ char **SoapySDRDevice_listSensors(const SoapySDRDevice *device, size_t *length)
     __SOAPY_SDR_C_TRY
     return toStrArray(device->listSensors(), length);
     __SOAPY_SDR_C_CATCH_RET(nullptr);
-}
-
-static SoapySDRArgInfo SoapySDRArgInfoNull(void)
-{
-    SoapySDRArgInfo info;
-    std::memset(&info, 0, sizeof(info));
-    return info;
 }
 
 SoapySDRArgInfo SoapySDRDevice_getSensorInfo(const SoapySDRDevice *device, const char *name)
@@ -729,7 +737,7 @@ void SoapySDRDevice_writeNamedRegister(SoapySDRDevice *device, const char *name,
 {
     __SOAPY_SDR_C_TRY
     return device->writeRegister(name, addr, value);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 unsigned SoapySDRDevice_readNamedRegister(const SoapySDRDevice *device, const char *name, const unsigned addr)
@@ -743,7 +751,7 @@ void SoapySDRDevice_writeRegister(SoapySDRDevice *device, const unsigned addr, c
 {
     __SOAPY_SDR_C_TRY
     return device->writeRegister(addr, value);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 unsigned SoapySDRDevice_readRegister(const SoapySDRDevice *device, const unsigned addr)
@@ -768,7 +776,7 @@ void SoapySDRDevice_writeSetting(SoapySDRDevice *device, const char *key, const 
 {
     __SOAPY_SDR_C_TRY
     return device->writeSetting(key, value);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 char *SoapySDRDevice_readSetting(const SoapySDRDevice *device, const char *key)
@@ -790,7 +798,7 @@ void SoapySDRDevice_writeChannelSetting(SoapySDRDevice *device, const int direct
 {
     __SOAPY_SDR_C_TRY
     return device->writeSetting(direction, channel, key, value);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 char *SoapySDRDevice_readChannelSetting(const SoapySDRDevice *device, const int direction, const size_t channel, const char *key)
@@ -815,14 +823,14 @@ void SoapySDRDevice_writeGPIO(SoapySDRDevice *device, const char *bank, const un
 {
     __SOAPY_SDR_C_TRY
     return device->writeGPIO(bank, value);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 void SoapySDRDevice_writeGPIOMasked(SoapySDRDevice *device, const char *bank, const unsigned value, const unsigned mask)
 {
     __SOAPY_SDR_C_TRY
     return device->writeGPIO(bank, value, mask);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 unsigned SoapySDRDevice_readGPIO(const SoapySDRDevice *device, const char *bank)
@@ -836,14 +844,14 @@ void SoapySDRDevice_writeGPIODir(SoapySDRDevice *device, const char *bank, const
 {
     __SOAPY_SDR_C_TRY
     return device->writeGPIODir(bank, dir);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 void SoapySDRDevice_writeGPIODirMasked(SoapySDRDevice *device, const char *bank, const unsigned dir, const unsigned mask)
 {
     __SOAPY_SDR_C_TRY
     return device->writeGPIODir(bank, dir, mask);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 unsigned SoapySDRDevice_readGPIODir(const SoapySDRDevice *device, const char *bank)
@@ -860,7 +868,7 @@ void SoapySDRDevice_writeI2C(SoapySDRDevice *device, const int addr, const char 
 {
     __SOAPY_SDR_C_TRY
     return device->writeI2C(addr, std::string(data, numBytes));
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 char *SoapySDRDevice_readI2C(SoapySDRDevice *device, const int addr, const size_t numBytes)
@@ -898,7 +906,7 @@ void SoapySDRDevice_writeUART(SoapySDRDevice *device, const char *which, const c
 {
     __SOAPY_SDR_C_TRY
     return device->writeUART(which, data);
-    __SOAPY_SDR_C_CATCH_RET();
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRVoidRet);
 }
 
 char *SoapySDRDevice_readUART(const SoapySDRDevice *device, const char *which, const long timeoutUs)

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -18,12 +18,26 @@
 #define __thread __declspec(thread)
 #endif
 
+static __thread int lastErrorStatus;
+
 static __thread char lastErrorMsg[1024];
+
+void SoapySDRDevice_clearError(void)
+{
+    lastErrorMsg[0] = '\0';
+    lastErrorStatus = 0;
+}
+
+int SoapySDRDevice_lastStatus(void)
+{
+    return lastErrorStatus;
+}
 
 void SoapySDRDevice_reportError(const char *msg)
 {
     strncpy(lastErrorMsg, msg, sizeof(lastErrorMsg));
     lastErrorMsg[sizeof(lastErrorMsg)-1] = '\0';
+    lastErrorStatus = -1;
 }
 
 const char *SoapySDRDevice_lastError(void)

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -108,6 +108,8 @@ int SoapySDRDevice_setupStream(SoapySDRDevice *device, SoapySDRStream **stream, 
     __SOAPY_SDR_C_TRY
     *stream = reinterpret_cast<SoapySDRStream *>(device->setupStream(direction, format, std::vector<size_t>(channels, channels+numChans), toKwargs(args)));
     __SOAPY_SDR_C_CATCH
+    //TODO this would be a better design to return the stream
+    //__SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_closeStream(SoapySDRDevice *device, SoapySDRStream *stream)

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -19,11 +19,10 @@
 
 static __thread char lastErrorMsg[1024];
 
-int SoapySDRDevice_reportError(const char *msg)
+void SoapySDRDevice_reportError(const char *msg)
 {
     strncpy(lastErrorMsg, msg, sizeof(lastErrorMsg));
     lastErrorMsg[sizeof(lastErrorMsg)-1] = '\0';
-    return -1;
 }
 
 const char *SoapySDRDevice_lastError(void)

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-2016 Bastille Networks
 // SPDX-License-Identifier: BSL-1.0
 
+#include "ErrorHelpers.hpp"
 #include "TypeHelpers.hpp"
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Device.hpp>
@@ -10,21 +11,15 @@
 #include <cstring>
 
 /*******************************************************************
- * Helper macros for dealing with error messages
+ * Error message implementation
  ******************************************************************/
-#define __SOAPY_SDR_C_TRY try {
-#define __SOAPY_SDR_C_CATCH } \
-    catch (const std::exception &ex) { return SoapySDRDevice_reportError(ex.what()); } \
-    catch (...) { return SoapySDRDevice_reportError("unknown"); } \
-    return 0;
-
 #ifdef _MSC_VER
 #define __thread __declspec(thread)
 #endif
 
 static __thread char lastErrorMsg[1024];
 
-static int SoapySDRDevice_reportError(const char *msg)
+int SoapySDRDevice_reportError(const char *msg)
 {
     strncpy(lastErrorMsg, msg, sizeof(lastErrorMsg));
     lastErrorMsg[sizeof(lastErrorMsg)-1] = '\0';

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -42,17 +42,23 @@ extern "C" {
  ******************************************************************/
 char *SoapySDRDevice_getDriverKey(const SoapySDRDevice *device)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getDriverKey().c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 char *SoapySDRDevice_getHardwareKey(const SoapySDRDevice *device)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getHardwareKey().c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRKwargs SoapySDRDevice_getHardwareInfo(const SoapySDRDevice *device)
 {
+    __SOAPY_SDR_C_TRY
     return toKwargs(device->getHardwareInfo());
+    __SOAPY_SDR_C_CATCH_RET(toKwargs(SoapySDR::Kwargs()));
 }
 
 /*******************************************************************
@@ -67,17 +73,23 @@ int SoapySDRDevice_setFrontendMapping(SoapySDRDevice *device, const int directio
 
 char *SoapySDRDevice_getFrontendMapping(const SoapySDRDevice *device, const int direction)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getFrontendMapping(direction).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 size_t SoapySDRDevice_getNumChannels(const SoapySDRDevice *device, const int direction)
 {
+    __SOAPY_SDR_C_TRY
     return device->getNumChannels(direction);
+    __SOAPY_SDR_C_CATCH_RET(std::string::npos);
 }
 
 SoapySDRKwargs SoapySDRDevice_getChannelInfo(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return toKwargs(device->getChannelInfo(direction, channel));
+    __SOAPY_SDR_C_CATCH_RET(toKwargs(SoapySDR::Kwargs()));
 }
 
 bool SoapySDRDevice_getFullDuplex(const SoapySDRDevice *device, const int direction, const size_t channel)
@@ -90,17 +102,23 @@ bool SoapySDRDevice_getFullDuplex(const SoapySDRDevice *device, const int direct
  ******************************************************************/
 char **SoapySDRDevice_getStreamFormats(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->getStreamFormats(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 char *SoapySDRDevice_getNativeStreamFormat(const SoapySDRDevice *device, const int direction, const size_t channel, double *fullScale)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getNativeStreamFormat(direction, channel, *fullScale).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRArgInfo *SoapySDRDevice_getStreamArgsInfo(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    __SOAPY_SDR_C_TRY
     return toArgInfoList(device->getStreamArgsInfo(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 int SoapySDRDevice_setupStream(SoapySDRDevice *device, SoapySDRStream **stream, const int direction, const char *format, const size_t *channels, const size_t numChans, const SoapySDRKwargs *args)

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <cmath> //NAN
 
 /*******************************************************************
  * Error message implementation
@@ -104,6 +105,7 @@ bool SoapySDRDevice_getFullDuplex(const SoapySDRDevice *device, const int direct
  ******************************************************************/
 char **SoapySDRDevice_getStreamFormats(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
     __SOAPY_SDR_C_TRY
     return toStrArray(device->getStreamFormats(direction, channel), length);
     __SOAPY_SDR_C_CATCH_RET(nullptr);
@@ -118,6 +120,7 @@ char *SoapySDRDevice_getNativeStreamFormat(const SoapySDRDevice *device, const i
 
 SoapySDRArgInfo *SoapySDRDevice_getStreamArgsInfo(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
     __SOAPY_SDR_C_TRY
     return toArgInfoList(device->getStreamArgsInfo(direction, channel), length);
     __SOAPY_SDR_C_CATCH_RET(nullptr);
@@ -255,6 +258,7 @@ void SoapySDRDevice_releaseWriteBuffer(SoapySDRDevice *device,
  ******************************************************************/
 char **SoapySDRDevice_listAntennas(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
     __SOAPY_SDR_C_TRY
     return toStrArray(device->listAntennas(direction, channel), length);
     __SOAPY_SDR_C_CATCH_RET(nullptr);
@@ -349,6 +353,7 @@ void SoapySDRDevice_getIQBalance(const SoapySDRDevice *device, const int directi
  ******************************************************************/
 char **SoapySDRDevice_listGains(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
     __SOAPY_SDR_C_TRY
     return toStrArray(device->listGains(direction, channel), length);
     __SOAPY_SDR_C_CATCH_RET(nullptr);
@@ -391,22 +396,32 @@ int SoapySDRDevice_setGainElement(SoapySDRDevice *device, const int direction, c
 
 double SoapySDRDevice_getGain(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getGain(direction, channel);
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
 
 double SoapySDRDevice_getGainElement(const SoapySDRDevice *device, const int direction, const size_t channel, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return device->getGain(direction, channel, name);
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
+
+static const SoapySDRRange SoapySDRRangeNAN = {NAN, NAN};
 
 SoapySDRRange SoapySDRDevice_getGainRange(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return toRange(device->getGainRange(direction, channel));
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRRangeNAN);
 }
 
 SoapySDRRange SoapySDRDevice_getGainElementRange(const SoapySDRDevice *device, const int direction, const size_t channel, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return toRange(device->getGainRange(direction, channel, name));
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRRangeNAN);
 }
 
 /*******************************************************************
@@ -428,32 +443,48 @@ int SoapySDRDevice_setFrequencyComponent(SoapySDRDevice *device, const int direc
 
 double SoapySDRDevice_getFrequency(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getFrequency(direction, channel);
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
 
 double SoapySDRDevice_getFrequencyComponent(const SoapySDRDevice *device, const int direction, const size_t channel, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return device->getFrequency(direction, channel, name);
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
 
 char **SoapySDRDevice_listFrequencies(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listFrequencies(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRRange *SoapySDRDevice_getFrequencyRange(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toRangeList(device->getFrequencyRange(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRRange *SoapySDRDevice_getFrequencyRangeComponent(const SoapySDRDevice *device, const int direction, const size_t channel, const char *name, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toRangeList(device->getFrequencyRange(direction, channel, name), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRArgInfo *SoapySDRDevice_getFrequencyArgsInfo(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toArgInfoList(device->getFrequencyArgsInfo(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -468,12 +499,17 @@ int SoapySDRDevice_setSampleRate(SoapySDRDevice *device, const int direction, co
 
 double SoapySDRDevice_getSampleRate(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getSampleRate(direction, channel);
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
 
 double *SoapySDRDevice_listSampleRates(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toNumericList(device->listSampleRates(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -488,17 +524,25 @@ int SoapySDRDevice_setBandwidth(SoapySDRDevice *device, const int direction, con
 
 double SoapySDRDevice_getBandwidth(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
+    __SOAPY_SDR_C_TRY
     return device->getBandwidth(direction, channel);
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
 
 double *SoapySDRDevice_listBandwidths(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toNumericList(device->listBandwidths(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRRange *SoapySDRDevice_getBandwidthRange(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toRangeList(device->getBandwidthRange(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -513,17 +557,25 @@ int SoapySDRDevice_setMasterClockRate(SoapySDRDevice *device, const double rate)
 
 double SoapySDRDevice_getMasterClockRate(const SoapySDRDevice *device)
 {
+    __SOAPY_SDR_C_TRY
     return device->getMasterClockRate();
+    __SOAPY_SDR_C_CATCH_RET(NAN);
 }
 
 SoapySDRRange *SoapySDRDevice_getMasterClockRates(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toRangeList(device->getMasterClockRates(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 char **SoapySDRDevice_listClockSources(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listClockSources(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 int SoapySDRDevice_setClockSource(SoapySDRDevice *device, const char *source)
@@ -535,7 +587,9 @@ int SoapySDRDevice_setClockSource(SoapySDRDevice *device, const char *source)
 
 char *SoapySDRDevice_getClockSource(const SoapySDRDevice *device)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getClockSource().c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -544,7 +598,10 @@ char *SoapySDRDevice_getClockSource(const SoapySDRDevice *device)
 
 char **SoapySDRDevice_listTimeSources(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listTimeSources(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 int SoapySDRDevice_setTimeSource(SoapySDRDevice *device, const char *source)
@@ -556,27 +613,37 @@ int SoapySDRDevice_setTimeSource(SoapySDRDevice *device, const char *source)
 
 char *SoapySDRDevice_getTimeSource(const SoapySDRDevice *device)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->getTimeSource().c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 bool SoapySDRDevice_hasHardwareTime(const SoapySDRDevice *device, const char *what)
 {
+    __SOAPY_SDR_C_TRY
     return device->hasHardwareTime(what);
+    __SOAPY_SDR_C_CATCH
 }
 
 long long SoapySDRDevice_getHardwareTime(const SoapySDRDevice *device, const char *what)
 {
+    __SOAPY_SDR_C_TRY
     return device->getHardwareTime(what);
+    __SOAPY_SDR_C_CATCH
 }
 
 void SoapySDRDevice_setHardwareTime(SoapySDRDevice *device, const long long timeNs, const char *what)
 {
+    __SOAPY_SDR_C_TRY
     device->setHardwareTime(timeNs, what);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 void SoapySDRDevice_setCommandTime(SoapySDRDevice *device, const long long timeNs, const char *what)
 {
+    __SOAPY_SDR_C_TRY
     device->setCommandTime(timeNs, what);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 /*******************************************************************
@@ -584,32 +651,53 @@ void SoapySDRDevice_setCommandTime(SoapySDRDevice *device, const long long timeN
  ******************************************************************/
 char **SoapySDRDevice_listSensors(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listSensors(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
+static SoapySDRArgInfo SoapySDRArgInfoNull(void)
+{
+    SoapySDRArgInfo info;
+    std::memset(&info, 0, sizeof(info));
+    return info;
 }
 
 SoapySDRArgInfo SoapySDRDevice_getSensorInfo(const SoapySDRDevice *device, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return toArgInfo(device->getSensorInfo(name));
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRArgInfoNull());
 }
 
 char *SoapySDRDevice_readSensor(const SoapySDRDevice *device, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->readSensor(name).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 char **SoapySDRDevice_listChannelSensors(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listSensors(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRArgInfo SoapySDRDevice_getChannelSensorInfo(const SoapySDRDevice *device, const int direction, const size_t channel, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return toArgInfo(device->getSensorInfo(direction, channel, name));
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRArgInfoNull());
 }
 
 char *SoapySDRDevice_readChannelSensor(const SoapySDRDevice *device, const int direction, const size_t channel, const char *name)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->readSensor(direction, channel, name).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -617,27 +705,38 @@ char *SoapySDRDevice_readChannelSensor(const SoapySDRDevice *device, const int d
  ******************************************************************/
 char **SoapySDRDevice_listRegisterInterfaces(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listRegisterInterfaces(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_writeNamedRegister(SoapySDRDevice *device, const char *name, const unsigned addr, const unsigned value)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeRegister(name, addr, value);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 unsigned SoapySDRDevice_readNamedRegister(const SoapySDRDevice *device, const char *name, const unsigned addr)
 {
+    __SOAPY_SDR_C_TRY
     return device->readRegister(name, addr);
+    __SOAPY_SDR_C_CATCH
 }
 
 void SoapySDRDevice_writeRegister(SoapySDRDevice *device, const unsigned addr, const unsigned value)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeRegister(addr, value);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 unsigned SoapySDRDevice_readRegister(const SoapySDRDevice *device, const unsigned addr)
 {
+    __SOAPY_SDR_C_TRY
     return device->readRegister(addr);
+    __SOAPY_SDR_C_CATCH
 }
 
 /*******************************************************************
@@ -645,32 +744,46 @@ unsigned SoapySDRDevice_readRegister(const SoapySDRDevice *device, const unsigne
  ******************************************************************/
 SoapySDRArgInfo *SoapySDRDevice_getSettingInfo(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toArgInfoList(device->getSettingInfo(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_writeSetting(SoapySDRDevice *device, const char *key, const char *value)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeSetting(key, value);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 char *SoapySDRDevice_readSetting(const SoapySDRDevice *device, const char *key)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->readSetting(key).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRArgInfo *SoapySDRDevice_getChannelSettingInfo(const SoapySDRDevice *device, const int direction, const size_t channel, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toArgInfoList(device->getSettingInfo(direction, channel), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_writeChannelSetting(SoapySDRDevice *device, const int direction, const size_t channel, const char *key, const char *value)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeSetting(direction, channel, key, value);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 char *SoapySDRDevice_readChannelSetting(const SoapySDRDevice *device, const int direction, const size_t channel, const char *key)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->readSetting(direction, channel, key).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -678,37 +791,52 @@ char *SoapySDRDevice_readChannelSetting(const SoapySDRDevice *device, const int 
  ******************************************************************/
 char **SoapySDRDevice_listGPIOBanks(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listGPIOBanks(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_writeGPIO(SoapySDRDevice *device, const char *bank, const unsigned value)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeGPIO(bank, value);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 void SoapySDRDevice_writeGPIOMasked(SoapySDRDevice *device, const char *bank, const unsigned value, const unsigned mask)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeGPIO(bank, value, mask);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 unsigned SoapySDRDevice_readGPIO(const SoapySDRDevice *device, const char *bank)
 {
+    __SOAPY_SDR_C_TRY
     return device->readGPIO(bank);
+    __SOAPY_SDR_C_CATCH
 }
 
 void SoapySDRDevice_writeGPIODir(SoapySDRDevice *device, const char *bank, const unsigned dir)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeGPIODir(bank, dir);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 void SoapySDRDevice_writeGPIODirMasked(SoapySDRDevice *device, const char *bank, const unsigned dir, const unsigned mask)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeGPIODir(bank, dir, mask);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 unsigned SoapySDRDevice_readGPIODir(const SoapySDRDevice *device, const char *bank)
 {
+    __SOAPY_SDR_C_TRY
     return device->readGPIODir(bank);
+    __SOAPY_SDR_C_CATCH
 }
 
 /*******************************************************************
@@ -716,15 +844,19 @@ unsigned SoapySDRDevice_readGPIODir(const SoapySDRDevice *device, const char *ba
  ******************************************************************/
 void SoapySDRDevice_writeI2C(SoapySDRDevice *device, const int addr, const char *data, const size_t numBytes)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeI2C(addr, std::string(data, numBytes));
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 char *SoapySDRDevice_readI2C(SoapySDRDevice *device, const int addr, const size_t numBytes)
 {
+    __SOAPY_SDR_C_TRY
     const std::string bytes = device->readI2C(addr, numBytes).c_str();
     char *buff = (char *)std::malloc(bytes.size());
     std::copy(bytes.begin(), bytes.end(), buff);
     return buff;
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 /*******************************************************************
@@ -732,7 +864,9 @@ char *SoapySDRDevice_readI2C(SoapySDRDevice *device, const int addr, const size_
  ******************************************************************/
 unsigned SoapySDRDevice_transactSPI(SoapySDRDevice *device, const int addr, const unsigned data, const size_t numBits)
 {
+    __SOAPY_SDR_C_TRY
     return device->transactSPI(addr, data, numBits);
+    __SOAPY_SDR_C_CATCH
 }
 
 /*******************************************************************
@@ -740,17 +874,24 @@ unsigned SoapySDRDevice_transactSPI(SoapySDRDevice *device, const int addr, cons
  ******************************************************************/
 char **SoapySDRDevice_listUARTs(const SoapySDRDevice *device, size_t *length)
 {
+    *length = 0;
+    __SOAPY_SDR_C_TRY
     return toStrArray(device->listUARTs(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_writeUART(SoapySDRDevice *device, const char *which, const char *data)
 {
+    __SOAPY_SDR_C_TRY
     return device->writeUART(which, data);
+    __SOAPY_SDR_C_CATCH_RET();
 }
 
 char *SoapySDRDevice_readUART(const SoapySDRDevice *device, const char *which, const long timeoutUs)
 {
+    __SOAPY_SDR_C_TRY
     return strdup(device->readUART(which, timeoutUs).c_str());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 } //extern "C"

--- a/lib/ErrorHelpers.hpp
+++ b/lib/ErrorHelpers.hpp
@@ -10,7 +10,8 @@
  ******************************************************************/
 
 //! Start a section with an open try brace
-#define __SOAPY_SDR_C_TRY try {
+#define __SOAPY_SDR_C_TRY \
+    SoapySDRDevice_clearError(); try {
 
 //! Close a section with a catch, with specified return code
 #define __SOAPY_SDR_C_CATCH_RET(ret) } \
@@ -20,6 +21,9 @@
 //! Close a section with a catch, -1 return on error
 #define __SOAPY_SDR_C_CATCH \
     __SOAPY_SDR_C_CATCH_RET(-1) return 0;
+
+//! Clear the error on try macro entry
+void SoapySDRDevice_clearError(void);
 
 //! Report error called by catch macro
 void SoapySDRDevice_reportError(const char *msg);

--- a/lib/ErrorHelpers.hpp
+++ b/lib/ErrorHelpers.hpp
@@ -14,8 +14,8 @@
 
 //! Close a section with a catch, with specified return code
 #define __SOAPY_SDR_C_CATCH_RET(ret) } \
-    catch (const std::exception &ex) { SoapySDRDevice_reportError(ex.what()); return (ret); } \
-    catch (...) { SoapySDRDevice_reportError("unknown"); return (ret); }
+    catch (const std::exception &ex) { SoapySDRDevice_reportError(ex.what()); return ret; } \
+    catch (...) { SoapySDRDevice_reportError("unknown"); return ret; }
 
 //! Close a section with a catch, -1 return on error
 #define __SOAPY_SDR_C_CATCH \

--- a/lib/ErrorHelpers.hpp
+++ b/lib/ErrorHelpers.hpp
@@ -8,10 +8,18 @@
 /*******************************************************************
  * Helper macros for dealing with error messages
  ******************************************************************/
+
+//! Start a section with an open try brace
 #define __SOAPY_SDR_C_TRY try {
-#define __SOAPY_SDR_C_CATCH } \
-    catch (const std::exception &ex) { return SoapySDRDevice_reportError(ex.what()); } \
-    catch (...) { return SoapySDRDevice_reportError("unknown"); } \
+
+//! Close a section with a catch, with specified return code
+#define __SOAPY_SDR_C_CATCH_RET(ret) } \
+    catch (const std::exception &ex) { SoapySDRDevice_reportError(ex.what()); return (ret); } \
+    catch (...) { SoapySDRDevice_reportError("unknown"); return (ret); } \
     return 0;
 
-int SoapySDRDevice_reportError(const char *msg);
+//! Close a section with a catch, -1 return on error
+#define __SOAPY_SDR_C_CATCH __SOAPY_SDR_C_CATCH_RET(-1)
+
+//! Report error called by catch macro
+void SoapySDRDevice_reportError(const char *msg);

--- a/lib/ErrorHelpers.hpp
+++ b/lib/ErrorHelpers.hpp
@@ -15,11 +15,11 @@
 //! Close a section with a catch, with specified return code
 #define __SOAPY_SDR_C_CATCH_RET(ret) } \
     catch (const std::exception &ex) { SoapySDRDevice_reportError(ex.what()); return (ret); } \
-    catch (...) { SoapySDRDevice_reportError("unknown"); return (ret); } \
-    return 0;
+    catch (...) { SoapySDRDevice_reportError("unknown"); return (ret); }
 
 //! Close a section with a catch, -1 return on error
-#define __SOAPY_SDR_C_CATCH __SOAPY_SDR_C_CATCH_RET(-1)
+#define __SOAPY_SDR_C_CATCH \
+    __SOAPY_SDR_C_CATCH_RET(-1) return 0;
 
 //! Report error called by catch macro
 void SoapySDRDevice_reportError(const char *msg);

--- a/lib/ErrorHelpers.hpp
+++ b/lib/ErrorHelpers.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2016 Josh Blum
+// SPDX-License-Identifier: BSL-1.0
+
+#pragma once
+#include <SoapySDR/Config.hpp>
+#include <stdexcept>
+
+/*******************************************************************
+ * Helper macros for dealing with error messages
+ ******************************************************************/
+#define __SOAPY_SDR_C_TRY try {
+#define __SOAPY_SDR_C_CATCH } \
+    catch (const std::exception &ex) { return SoapySDRDevice_reportError(ex.what()); } \
+    catch (...) { return SoapySDRDevice_reportError("unknown"); } \
+    return 0;
+
+int SoapySDRDevice_reportError(const char *msg);

--- a/lib/FactoryC.cpp
+++ b/lib/FactoryC.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
+#include "ErrorHelpers.hpp"
 #include "TypeHelpers.hpp"
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Device.hpp>
@@ -21,12 +22,16 @@ SOAPY_SDR_API SoapySDRKwargs *SoapySDRDevice_enumerateStrArgs(const char *args, 
 
 SoapySDRDevice *SoapySDRDevice_make(const SoapySDRKwargs *args)
 {
+    __SOAPY_SDR_C_TRY
     return (SoapySDRDevice *)SoapySDR::Device::make(toKwargs(args));
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 SoapySDRDevice *SoapySDRDevice_makeStrArgs(const char *args)
 {
+    __SOAPY_SDR_C_TRY
     return (SoapySDRDevice *)SoapySDR::Device::make(args);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRDevice_unmake(SoapySDRDevice *device)


### PR DESCRIPTION
This PR represents additional try/catch blocks for C API device calls. This causes graceful returns with error message set (vs std::terminate when the uncaught exception throws in C). The API was not properly set up to provide error return codes. We are not introducing any C API changes in this commit. This is a fix commit for 0.5 series; so the following was done for existing calls:

* All errors thrown set SoapySDRDevice_lastError()
* API calls that returned points will return NULL on error
* API calls that return PODs return -1 or NAN (whatever fits)
* API calls that return void set the error, but there is nothing to show
* Because error cannot be determined for all return types, a ``int SoapySDRDevice_lastStatus()`` is provided to determine the error state of the last device API call.

Related issue: https://github.com/pothosware/SoapySDR/issues/95