### PR TITLE
Snappy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ enable_testing()
 # gather version information
 # packagers may specify -DSOAPY_SDR_EXTVER="foo" to replace the git hash
 ########################################################################
-set(SOAPY_SDR_LIBVER "0.5.3")
+set(SOAPY_SDR_LIBVER "0.5.4")
 
 if (NOT SOAPY_SDR_EXTVER)
     include(${PROJECT_SOURCE_DIR}/cmake/GetGitRevisionDescription.cmake)
@@ -31,6 +31,13 @@ set(SOAPY_SDR_VERSION "${SOAPY_SDR_LIBVER}-${SOAPY_SDR_EXTVER}")
 if(NOT SOAPY_SDR_ROOT)
     file(TO_CMAKE_PATH ${CMAKE_INSTALL_PREFIX} SOAPY_SDR_ROOT)
 endif(NOT SOAPY_SDR_ROOT)
+
+#SOAPY_SDR_ROOT_ENV is the name of the environment variable
+#which tells SoapySDR where to find the root installation.
+#By default, the environment variable SOAPY_SDR_ROOT is used.
+#Example: set -DSOAPY_SDR_ROOT_ENV=SNAP for snappy packages.
+set(SOAPY_SDR_ROOT_ENV "SOAPY_SDR_ROOT" CACHE STRING
+    "Environment variable for SoapySDR::getRootPath()")
 
 ########################################################################
 # select the release build type by default to get optimization flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,9 @@ set(SOAPY_SDR_VERSION "${SOAPY_SDR_LIBVER}-${SOAPY_SDR_EXTVER}")
 #SOAPY_SDR_ROOT is compiled into the library to locate the install base.
 #By default, the SOAPY_SDR_ROOT is set to the CMAKE_INSTALL_PREFIX.
 #However users may overload this by specifying -DSOAPY_SDR_ROOT=<path>.
-if(NOT SOAPY_SDR_ROOT)
-    file(TO_CMAKE_PATH ${CMAKE_INSTALL_PREFIX} SOAPY_SDR_ROOT)
-endif(NOT SOAPY_SDR_ROOT)
+set(SOAPY_SDR_ROOT "${CMAKE_INSTALL_PREFIX}" CACHE PATH
+    "Installation root for SoapySDR::getRootPath()")
+file(TO_CMAKE_PATH "${SOAPY_SDR_ROOT}" SOAPY_SDR_ROOT)
 
 #SOAPY_SDR_ROOT_ENV is the name of the environment variable
 #which tells SoapySDR where to find the root installation.

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the SoapySDR project.
 Release 0.5.4 (pending)
 ==========================
 
+- Dynamic root environment variable to support snappy packages
 - Windows: disable graphical error pop-ups when DLLs are not found
 - Debian: replaced recommends with soapysdr-modules-all metapackage
 

--- a/lib/Modules.in.cpp
+++ b/lib/Modules.in.cpp
@@ -39,7 +39,7 @@ std::string getEnvImpl(const char *name)
 
 std::string SoapySDR::getRootPath(void)
 {
-    const std::string rootPathEnv = getEnvImpl("SOAPY_SDR_ROOT");
+    const std::string rootPathEnv = getEnvImpl("@SOAPY_SDR_ROOT_ENV@");
     if (not rootPathEnv.empty()) return rootPathEnv;
 
     // Get the path to the current dynamic linked library.


### PR DESCRIPTION
Merging into maint for an eventual 0.5.4 release tag

* Added SOAPY_SDR_ROOT_ENV to cmake and root path to control the environment variable used to locate the root in a dynamically re-located file systems -- in this case a snap install that uses the SNAP environment variable

* Modified SOAPY_SDR_ROOT to match style and to deal with empty default, because CMAKE_INSTALL_PREFIX is set to empty in snap build