### PR TITLE
Fix device table keying

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,7 @@ Device C API changes:
 
 General additions and changes:
 
+- Device factory table keys based on enumeration results
 - Added optional step size to the range type
 - Added rate testing to SoapySDRUtil application
 - Added listSearchPaths() API and SoapySDRUtil print


### PR DESCRIPTION
Only the result of enumerate() is used to key the devices in the factory table. This ensures an accurate table regardless of optional arguments passed in by the user.

* Resolves https://github.com/pothosware/SoapySDR/issues/116