### PR TITLE
fix travis python test - explicit python2 executable path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,10 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      env:
-        global:
-          - PYTHON_EXECUTABLE=/usr/bin/python
-          - PYTHON3_EXECUTABLE=/usr/bin/python3
+      env: PYTHON_EXECUTABLE=/usr/bin/python PYTHON3_EXECUTABLE=/usr/bin/python3
     - os: osx
       compiler: clang
-      env:
-        global:
-          - PYTHON_EXECUTABLE=/usr/local/bin/python
-          - PYTHON3_EXECUTABLE=/usr/local/bin/python3
+      env: PYTHON_EXECUTABLE=/usr/local/bin/python PYTHON3_EXECUTABLE=/usr/local/bin/python3
 
 env:
   global:


### PR DESCRIPTION
Travis CI mysteriously broke the python2 unit tests. Could be a travis environment change for python executable paths. Open this PR to push commits until its resolved.