### PR TITLE
Remove loadModules() in enumerate()

### DIFF
--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -204,10 +204,6 @@ static int probeDevice(const std::string &argStr)
  **********************************************************************/
 static int checkDriver(const std::string &driverName)
 {
-    std::cout << "Loading modules... " << std::flush;
-    SoapySDR::loadModules();
-    std::cout << "done" << std::endl;
-
     std::cout << "Checking driver '" << driverName << "'... " << std::flush;
     const auto factories = SoapySDR::Registry::listFindFunctions();
 
@@ -303,6 +299,11 @@ int main(int argc, char *argv[])
     }
 
     if (not sparsePrintFlag) printBanner();
+
+    std::cout << "Loading modules... " << std::flush;
+    SoapySDR::loadModules();
+    std::cout << "done" << std::endl;
+
     if (not driverName.empty()) return checkDriver(driverName);
     if (findDevicesFlag) return findDevices(argStr, sparsePrintFlag);
     if (makeDeviceFlag)  return makeDevice(argStr);

--- a/lib/Factory.cpp
+++ b/lib/Factory.cpp
@@ -34,7 +34,6 @@ SoapySDR::KwargsList SoapySDR::Device::enumerate(const Kwargs &args)
 {
     std::lock_guard<std::recursive_mutex> lock(getFactoryMutex());
 
-    loadModules();
     SoapySDR::KwargsList results;
     for (const auto &it : Registry::listFindFunctions())
     {


### PR DESCRIPTION
When attempting to just load specific modules the enumerate() function would automatically call loadModules() -- this may unexpectedly force an application to load other system modules (i.e. CubicSDR OSX bundles)

Hopefully this isn't already widely-used and expected behaviour for enumerate() as I think it would be more flexible without forcing it.