### PR TITLE
support parallel device construction

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the SoapySDR project.
 Release 0.7.0 (pending)
 ==========================
 
+- Support parallel device factory construction/destruction
 - Added error handling and return code to SoapySDRKwargs_set()
 - Support list of module files in the search path
 - Disable automatic module load when loadModule is used first

--- a/include/SoapySDR/Device.h
+++ b/include/SoapySDR/Device.h
@@ -8,7 +8,7 @@
 /// The caller must free non-const array results.
 ///
 /// \copyright
-/// Copyright (c) 2014-2017 Josh Blum
+/// Copyright (c) 2014-2018 Josh Blum
 /// Copyright (c) 2016-2016 Bastille Networks
 /// SPDX-License-Identifier: BSL-1.0
 ///
@@ -95,6 +95,33 @@ SOAPY_SDR_API SoapySDRDevice *SoapySDRDevice_makeStrArgs(const char *args);
  * \return 0 for success or error code on failure
  */
 SOAPY_SDR_API int SoapySDRDevice_unmake(SoapySDRDevice *device);
+
+/*******************************************************************
+ * Parallel support
+ ******************************************************************/
+
+/*!
+ * Create a list of devices from a list of construction arguments.
+ * This is a convenience call to parallelize device construction,
+ * and is fundamentally a parallel for loop of make(Kwargs).
+ *
+ * \param argsList a list of device arguments per each device
+ * \param length the length of the argsList array
+ * \return a list of device pointers per each specified argument
+ */
+SOAPY_SDR_API SoapySDRDevice **SoapySDRDevice_make_list(SoapySDRKwargs *argsList, const size_t length);
+
+/*!
+ * Unmake or release a list of device handles
+ * and free the devices array memory as well.
+ * This is a convenience call to parallelize device destruction,
+ * and is fundamentally a parallel for loop of unmake(Device *).
+ *
+ * \param devices a list of pointers to device objects
+ * \param length the length of the devices array
+ * \return 0 for success or error code on failure
+ */
+SOAPY_SDR_API int SoapySDRDevice_unmake_list(SoapySDRDevice **devices, const size_t length);
 
 /*******************************************************************
  * Identification API

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -4,7 +4,7 @@
 /// Interface definition for Soapy SDR devices.
 ///
 /// \copyright
-/// Copyright (c) 2014-2017 Josh Blum
+/// Copyright (c) 2014-2018 Josh Blum
 /// Copyright (c) 2016-2016 Bastille Networks
 /// SPDX-License-Identifier: BSL-1.0
 ///
@@ -78,6 +78,29 @@ public:
      * \param device a pointer to a device object
      */
     static void unmake(Device *device);
+
+    /*******************************************************************
+     * Parallel support
+     ******************************************************************/
+
+    /*!
+     * Create a list of devices from a list of construction arguments.
+     * This is a convenience call to parallelize device construction,
+     * and is fundamentally a parallel for loop of make(Kwargs).
+     *
+     * \param argsList a list of device arguments per each device
+     * \return a list of device pointers per each specified argument
+     */
+    static std::vector<Device *> make(const KwargsList &argsList);
+
+    /*!
+     * Unmake or release a list of device handles.
+     * This is a convenience call to parallelize device destruction,
+     * and is fundamentally a parallel for loop of unmake(Device *).
+     *
+     * \param devices a list of pointers to device objects
+     */
+    static void unmake(const std::vector<Device *> &devices);
 
     /*******************************************************************
      * Identification API

--- a/lib/Factory.cpp
+++ b/lib/Factory.cpp
@@ -6,7 +6,6 @@
 #include <SoapySDR/Modules.hpp>
 #include <SoapySDR/Logger.hpp>
 #include <stdexcept>
-#include <iostream>
 #include <future>
 #include <chrono>
 #include <mutex>
@@ -91,20 +90,19 @@ SoapySDR::KwargsList SoapySDR::Device::enumerate(const Kwargs &args)
     {
         try
         {
-            auto results0 = it.second.get();
-            for (size_t i = 0; i < results0.size(); i++)
+            for (auto handle : it.second.get())
             {
-                results0[i]["driver"] = it.first;
-                results.push_back(results0[i]);
+                handle["driver"] = it.first;
+                results.push_back(handle);
             }
         }
         catch (const std::exception &ex)
         {
-            std::cerr << "SoapySDR::Device::enumerate(" << it.first << ") " << ex.what() << std::endl;
+            SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::Device::enumerate(%s) %s", it.first.c_str(), ex.what());
         }
         catch (...)
         {
-            std::cerr << "SoapySDR::Device::enumerate(" << it.first << ") " << "unknown error" << std::endl;
+            SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::Device::enumerate(%s) unknown error", it.first.c_str());
         }
     }
     return results;

--- a/lib/Factory.cpp
+++ b/lib/Factory.cpp
@@ -50,7 +50,7 @@ SoapySDR::KwargsList SoapySDR::Device::enumerate(const Kwargs &args)
     //clean expired entries from the cache
     {
         const auto now = std::chrono::high_resolution_clock::now();
-        std::unique_lock<std::recursive_mutex> lock(cacheMutex);
+        std::lock_guard<std::recursive_mutex> lock(cacheMutex);
         for (auto it = cache.begin(); it != cache.end();)
         {
             if (it->second.first < now) cache.erase(it++);
@@ -66,7 +66,7 @@ SoapySDR::KwargsList SoapySDR::Device::enumerate(const Kwargs &args)
         if (specifiedDriver and args.at("driver") != it.first) continue;
 
         //protect the cache to search it for results and update it
-        std::unique_lock<std::recursive_mutex> lock(cacheMutex);
+        std::lock_guard<std::recursive_mutex> lock(cacheMutex);
         auto &cacheEntry = cache[std::make_pair(it.first, args)];
 
         //use the cache entry if its been initialized (valid) and not expired

--- a/lib/FactoryC.cpp
+++ b/lib/FactoryC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2018 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "ErrorHelpers.hpp"
@@ -44,6 +44,29 @@ int SoapySDRDevice_unmake(SoapySDRDevice *device)
 {
     __SOAPY_SDR_C_TRY
     SoapySDR::Device::unmake((SoapySDR::Device *)device);
+    __SOAPY_SDR_C_CATCH
+}
+
+/*******************************************************************
+ * Parallel support
+ ******************************************************************/
+SoapySDRDevice **SoapySDRDevice_make_each(SoapySDRKwargs *argsList, const size_t length)
+{
+    __SOAPY_SDR_C_TRY
+    const auto devices = SoapySDR::Device::make(toKwargsList(argsList, length));
+    auto outDevices = (SoapySDRDevice **)calloc(length, sizeof(SoapySDRDevice *));
+    for (size_t i = 0; i < length; i++) outDevices[i] = (SoapySDRDevice *)devices[i];
+    return outDevices;
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
+int SoapySDRDevice_unmake_each(SoapySDRDevice **devices, const size_t length)
+{
+    __SOAPY_SDR_C_TRY
+    std::vector<SoapySDR::Device *> devicesVector(length);
+    for (size_t i = 0; i < length; i++) devicesVector[i] = (SoapySDR::Device *)devices[i];
+    free(devices);
+    SoapySDR::Device::unmake(devicesVector);
     __SOAPY_SDR_C_CATCH
 }
 

--- a/lib/TypeHelpers.hpp
+++ b/lib/TypeHelpers.hpp
@@ -104,6 +104,13 @@ static inline SoapySDRKwargs *toKwargsList(const SoapySDR::KwargsList &args, siz
     return outArgs;
 }
 
+static inline SoapySDR::KwargsList toKwargsList(const SoapySDRKwargs *args, const size_t length)
+{
+    SoapySDR::KwargsList outArgs(length);
+    for (size_t i = 0; i < length; i++) outArgs[i] = toKwargs(args+i);
+    return outArgs;
+}
+
 static inline SoapySDRArgInfo toArgInfo(const SoapySDR::ArgInfo &info)
 {
     SoapySDRArgInfo out;

--- a/python/SoapySDR.i
+++ b/python/SoapySDR.i
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2018 Josh Blum
 // Copyright (c) 2016-2016 Bastille Networks
 // SPDX-License-Identifier: BSL-1.0
 
@@ -59,6 +59,7 @@
 %template(SoapySDRRangeList) std::vector<SoapySDR::Range>;
 %template(SoapySDRSizeList) std::vector<size_t>;
 %template(SoapySDRDoubleList) std::vector<double>;
+%template(SoapySDRDeviceList) std::vector<SoapySDR::Device *>;
 
 %extend std::map<std::string, std::string>
 {
@@ -153,7 +154,6 @@ for key in sorted(globals().keys()):
 //make device a constructable class
 %insert("python")
 %{
-_Device = Device
 class Device(Device):
     def __new__(cls, *args, **kwargs):
         return cls.make(*args, **kwargs)


### PR DESCRIPTION
* Device::make, Device::unmake, and Device::enumerate can be called in from multiple threads
* Convenience calls Device::make(argslist) and Device::unmake(devicelist) to parallelize creating an array of devices from an array of handles (and cleanup)