### PR TITLE
addtional checks for bad allocs - c only wrappers

### DIFF
--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -73,14 +73,14 @@ extern "C" {
 char *SoapySDRDevice_getDriverKey(const SoapySDRDevice *device)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getDriverKey().c_str());
+    return toCString(device->getDriverKey());
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 char *SoapySDRDevice_getHardwareKey(const SoapySDRDevice *device)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getHardwareKey().c_str());
+    return toCString(device->getHardwareKey());
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -104,7 +104,7 @@ int SoapySDRDevice_setFrontendMapping(SoapySDRDevice *device, const int directio
 char *SoapySDRDevice_getFrontendMapping(const SoapySDRDevice *device, const int direction)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getFrontendMapping(direction).c_str());
+    return toCString(device->getFrontendMapping(direction));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -143,7 +143,7 @@ char **SoapySDRDevice_getStreamFormats(const SoapySDRDevice *device, const int d
 char *SoapySDRDevice_getNativeStreamFormat(const SoapySDRDevice *device, const int direction, const size_t channel, double *fullScale)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getNativeStreamFormat(direction, channel, *fullScale).c_str());
+    return toCString(device->getNativeStreamFormat(direction, channel, *fullScale));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -303,7 +303,7 @@ int SoapySDRDevice_setAntenna(SoapySDRDevice *device, const int direction, const
 char *SoapySDRDevice_getAntenna(const SoapySDRDevice *device, const int direction, const size_t channel)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getAntenna(direction, channel).c_str());
+    return toCString(device->getAntenna(direction, channel));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -644,7 +644,7 @@ int SoapySDRDevice_setClockSource(SoapySDRDevice *device, const char *source)
 char *SoapySDRDevice_getClockSource(const SoapySDRDevice *device)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getClockSource().c_str());
+    return toCString(device->getClockSource());
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -670,7 +670,7 @@ int SoapySDRDevice_setTimeSource(SoapySDRDevice *device, const char *source)
 char *SoapySDRDevice_getTimeSource(const SoapySDRDevice *device)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->getTimeSource().c_str());
+    return toCString(device->getTimeSource());
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -723,7 +723,7 @@ SoapySDRArgInfo SoapySDRDevice_getSensorInfo(const SoapySDRDevice *device, const
 char *SoapySDRDevice_readSensor(const SoapySDRDevice *device, const char *key)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->readSensor(key).c_str());
+    return toCString(device->readSensor(key));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -745,7 +745,7 @@ SoapySDRArgInfo SoapySDRDevice_getChannelSensorInfo(const SoapySDRDevice *device
 char *SoapySDRDevice_readChannelSensor(const SoapySDRDevice *device, const int direction, const size_t channel, const char *key)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->readSensor(direction, channel, key).c_str());
+    return toCString(device->readSensor(direction, channel, key));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -812,7 +812,7 @@ int SoapySDRDevice_writeSetting(SoapySDRDevice *device, const char *key, const c
 char *SoapySDRDevice_readSetting(const SoapySDRDevice *device, const char *key)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->readSetting(key).c_str());
+    return toCString(device->readSetting(key));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -834,7 +834,7 @@ int SoapySDRDevice_writeChannelSetting(SoapySDRDevice *device, const int directi
 char *SoapySDRDevice_readChannelSetting(const SoapySDRDevice *device, const int direction, const size_t channel, const char *key)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->readSetting(direction, channel, key).c_str());
+    return toCString(device->readSetting(direction, channel, key));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
@@ -907,7 +907,7 @@ char *SoapySDRDevice_readI2C(SoapySDRDevice *device, const int addr, size_t *num
     *numBytes = 0; //clear in case of error
 
     __SOAPY_SDR_C_TRY
-    const std::string bytes = device->readI2C(addr, inputNumBytes).c_str();
+    const auto bytes = device->readI2C(addr, inputNumBytes);
     char *buff = (char *)std::malloc(bytes.size());
     std::copy(bytes.begin(), bytes.end(), buff);
     *numBytes = bytes.size();
@@ -946,7 +946,7 @@ int SoapySDRDevice_writeUART(SoapySDRDevice *device, const char *which, const ch
 char *SoapySDRDevice_readUART(const SoapySDRDevice *device, const char *which, const long timeoutUs)
 {
     __SOAPY_SDR_C_TRY
-    return strdup(device->readUART(which, timeoutUs).c_str());
+    return toCString(device->readUART(which, timeoutUs));
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2018 Josh Blum
 // Copyright (c) 2016-2016 Bastille Networks
 // SPDX-License-Identifier: BSL-1.0
 

--- a/lib/LoggerC.cpp
+++ b/lib/LoggerC.cpp
@@ -45,6 +45,7 @@ int vasprintf(char **strp, const char *fmt, va_list ap)
     int r = _vscprintf(fmt, ap);
     if (r < 0) return r;
     *strp = (char *)malloc(r+1);
+    if (*strp == nullptr) return -1;
     return vsprintf_s(*strp, r+1, fmt, ap);
 }
 #endif

--- a/lib/TypeHelpers.hpp
+++ b/lib/TypeHelpers.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2018 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -9,16 +9,35 @@
 #include <string>
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
+#include <algorithm>
 
 /*******************************************************************
  * Helpful converters
  ******************************************************************/
+static inline char *toCString(const std::string &s)
+{
+    auto out = (char *)calloc(s.size()+1, sizeof(char));
+    if (out == nullptr) throw std::bad_alloc();
+    std::copy(s.begin(), s.end(), out);
+    return out;
+}
+
 static inline char **toStrArray(const std::vector<std::string> &strs, size_t *length)
 {
-    char **out = (char **)calloc(strs.size(), sizeof(char *));
+    auto out = (char **)calloc(strs.size(), sizeof(char *));
+    if (out == nullptr) throw std::bad_alloc();
     for (size_t i = 0; i < strs.size(); i++)
     {
-        out[i] = strdup(strs[i].c_str());
+        try
+        {
+            out[i] = toCString(strs[i]);
+        }
+        catch (const std::bad_alloc &)
+        {
+            SoapySDRStrings_clear(&out, i);
+            throw;
+        }
     }
     *length = strs.size();
     return out;
@@ -35,7 +54,8 @@ static inline SoapySDRRange toRange(const SoapySDR::Range &range)
 
 static inline SoapySDRRange *toRangeList(const SoapySDR::RangeList &ranges, size_t *length)
 {
-    SoapySDRRange *out = (SoapySDRRange *)calloc(ranges.size(), sizeof(SoapySDRRange));
+    auto out = (SoapySDRRange *)calloc(ranges.size(), sizeof(SoapySDRRange));
+    if (out == nullptr) throw std::bad_alloc();
     for (size_t i = 0; i < ranges.size(); i++) out[i] = toRange(ranges[i]);
     *length = ranges.size();
     return out;
@@ -43,8 +63,9 @@ static inline SoapySDRRange *toRangeList(const SoapySDR::RangeList &ranges, size
 
 static inline double *toNumericList(const std::vector<double> &values, size_t *length)
 {
-    double *out = (double *)calloc(values.size(), sizeof(double));
-    for (size_t i = 0; i < values.size(); i++) out[i] = values[i];
+    auto out = (double *)calloc(values.size(), sizeof(double));
+    if (out == nullptr) throw std::bad_alloc();
+    std::copy(values.begin(), values.end(), out);
     *length = values.size();
     return out;
 }
@@ -66,14 +87,18 @@ static inline SoapySDRKwargs toKwargs(const SoapySDR::Kwargs &args)
     std::memset(&out, 0, sizeof(out));
     for (const auto &it : args)
     {
-        SoapySDRKwargs_set(&out, it.first.c_str(), it.second.c_str());
+        if (SoapySDRKwargs_set(&out, it.first.c_str(), it.second.c_str()) != 0)
+        {
+            throw std::bad_alloc();
+        }
     }
     return out;
 }
 
 static inline SoapySDRKwargs *toKwargsList(const SoapySDR::KwargsList &args, size_t *length)
 {
-    SoapySDRKwargs *outArgs = (SoapySDRKwargs *)calloc(args.size(), sizeof(SoapySDRKwargs));
+    auto outArgs = (SoapySDRKwargs *)calloc(args.size(), sizeof(SoapySDRKwargs));
+    if (outArgs == nullptr) throw std::bad_alloc();
     for (size_t i = 0; i < args.size(); i++) outArgs[i] = toKwargs(args[i]);
     *length = args.size();
     return outArgs;
@@ -82,21 +107,31 @@ static inline SoapySDRKwargs *toKwargsList(const SoapySDR::KwargsList &args, siz
 static inline SoapySDRArgInfo toArgInfo(const SoapySDR::ArgInfo &info)
 {
     SoapySDRArgInfo out;
-    out.key = strdup(info.key.c_str());
-    out.name = strdup(info.name.c_str());
-    out.description = strdup(info.description.c_str());
-    out.units = strdup(info.units.c_str());
-    out.type = SoapySDRArgInfoType(info.type);
-    out.range = toRange(info.range);
-    out.options = toStrArray(info.options, &out.numOptions);
-    out.optionNames = toStrArray(info.optionNames, &out.numOptions);
+    std::memset(&out, 0, sizeof(out));
+    try
+    {
+        out.key = toCString(info.key);
+        out.name = toCString(info.name);
+        out.description = toCString(info.description);
+        out.units = toCString(info.units);
+        out.type = SoapySDRArgInfoType(info.type);
+        out.range = toRange(info.range);
+        out.options = toStrArray(info.options, &out.numOptions);
+        out.optionNames = toStrArray(info.optionNames, &out.numOptions);
+    }
+    catch (const std::bad_alloc &)
+    {
+        SoapySDRArgInfo_clear(&out);
+        throw;
+    }
 
     return out;
 }
 
 static inline SoapySDRArgInfo *toArgInfoList(const SoapySDR::ArgInfoList &infos, size_t *length)
 {
-    SoapySDRArgInfo *out = (SoapySDRArgInfo *)calloc(infos.size(), sizeof(SoapySDRArgInfo));
+    auto out = (SoapySDRArgInfo *)calloc(infos.size(), sizeof(SoapySDRArgInfo));
+    if (out == nullptr) throw std::bad_alloc();
     for (size_t i = 0; i < infos.size(); i++)
     {
         out[i] = toArgInfo(infos[i]);
@@ -107,15 +142,16 @@ static inline SoapySDRArgInfo *toArgInfoList(const SoapySDR::ArgInfoList &infos,
 
 static inline std::vector<unsigned> toNumericVector(const unsigned *values, size_t length)
 {
-	std::vector<unsigned> out (length, 0);
-    for (size_t i = 0; i < length; i++) out[i] = values[i];
+    std::vector<unsigned> out (length, 0);
+    std::copy(values, values+length, out.data());
     return out;
 }
 
 static inline unsigned *toNumericList(const std::vector<unsigned> &values, size_t *length)
 {
-	unsigned *out = (unsigned *)calloc(values.size(), sizeof(unsigned));
-    for (size_t i = 0; i < values.size(); i++) out[i] = values[i];
+    auto out = (unsigned *)calloc(values.size(), sizeof(unsigned));
+    if (out == nullptr) throw std::bad_alloc();
+    std::copy(values.begin(), values.end(), out);
     *length = values.size();
     return out;
 }

--- a/lib/TypesC.cpp
+++ b/lib/TypesC.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2014-2018 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
+#include "ErrorHelpers.hpp"
 #include "TypeHelpers.hpp"
 #include <SoapySDR/Types.h>
 #include <cstdlib>
@@ -10,12 +11,16 @@ extern "C" {
 
 SoapySDRKwargs SoapySDRKwargs_fromString(const char *markup)
 {
+    __SOAPY_SDR_C_TRY
     return toKwargs(SoapySDR::KwargsFromString(markup));
+    __SOAPY_SDR_C_CATCH_RET(SoapySDRKwargs());
 }
 
 char *SoapySDRKwargs_toString(const SoapySDRKwargs *args)
 {
+    __SOAPY_SDR_C_TRY
     return toCString(SoapySDR::KwargsToString(toKwargs(args)));
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
 void SoapySDRStrings_clear(char ***elems, const size_t length)

--- a/lib/TypesC.cpp
+++ b/lib/TypesC.cpp
@@ -15,7 +15,7 @@ SoapySDRKwargs SoapySDRKwargs_fromString(const char *markup)
 
 char *SoapySDRKwargs_toString(const SoapySDRKwargs *args)
 {
-    return strdup(SoapySDR::KwargsToString(toKwargs(args)).c_str());
+    return toCString(SoapySDR::KwargsToString(toKwargs(args)));
 }
 
 void SoapySDRStrings_clear(char ***elems, const size_t length)


### PR DESCRIPTION
* Type conversions get calloc fail checks and others
* added other general error checks
* Added type helper for string to character array
* use std::copy where applicable
* throw bad_alloc on fail (caught by try/catch in c wrappers)