### PR TITLE
copying missing `value` field in SoapySDRArgInfo C wrapper

### DIFF
--- a/lib/TypeHelpers.hpp
+++ b/lib/TypeHelpers.hpp
@@ -118,6 +118,7 @@ static inline SoapySDRArgInfo toArgInfo(const SoapySDR::ArgInfo &info)
     try
     {
         out.key = toCString(info.key);
+        out.value = toCString(info.value);
         out.name = toCString(info.name);
         out.description = toCString(info.description);
         out.units = toCString(info.units);


### PR DESCRIPTION
the "value" field of the SoapySDRArgInfo type was not being copied from C++ land to C land, causing segfaults in code that used it.  This adds the missing copy operation.