### PR TITLE
Update to modern cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,19 +93,22 @@ find_package(SoapySDR CONFIG REQUIRED)
 ########################################################################
 # Install cmake helper modules
 ########################################################################
+if (UNIX)
+    set(CMAKE_LIB_DEST share/cmake/${PROJECT_NAME})
+elseif (WIN32)
+    set(CMAKE_LIB_DEST cmake)
+endif ()
+
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/Modules/SoapySDRConfigVersion.in.cmake
     ${PROJECT_BINARY_DIR}/SoapySDRConfigVersion.cmake
 @ONLY)
-set(cmake_files
+
+install(FILES
     ${PROJECT_SOURCE_DIR}/cmake/Modules/SoapySDRConfig.cmake
     ${PROJECT_SOURCE_DIR}/cmake/Modules/SoapySDRUtil.cmake
-    ${PROJECT_BINARY_DIR}/SoapySDRConfigVersion.cmake)
-if (UNIX)
-    install(FILES ${cmake_files} DESTINATION share/cmake/${PROJECT_NAME})
-elseif (WIN32)
-    install(FILES ${cmake_files} DESTINATION cmake)
-endif ()
+    ${PROJECT_BINARY_DIR}/SoapySDRConfigVersion.cmake
+    DESTINATION ${CMAKE_LIB_DEST})
 
 ########################################################################
 # Install headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.1.0)
 project(SoapySDR)
 enable_language(CXX)
 enable_testing()
+
+#C++11 is a required language feature for this project
+set(CMAKE_CXX_STANDARD 11)
 
 ########################################################################
 # gather version information
@@ -85,8 +88,7 @@ endif()
 ########################################################################
 set(SoapySDR_DIR ${PROJECT_SOURCE_DIR}/cmake/Modules)
 set(SOAPY_SDR_IN_TREE_SOURCE_DIR ${PROJECT_SOURCE_DIR})
-find_package(SoapySDR NO_MODULE REQUIRED)
-include_directories(${SoapySDR_INCLUDE_DIRS}) #local include precedence
+find_package(SoapySDR CONFIG REQUIRED)
 
 ########################################################################
 # Install cmake helper modules

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,10 +1,5 @@
 This this the changelog file for the SoapySDR project.
 
-Release 0.7.1 (pending)
-==========================
-
-- Move visibility flags from project config to library scope
-
 Release 0.7.0 (2018-10-24)
 ==========================
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -12,19 +12,15 @@ endif()
 ########################################################################
 # Build utility executable
 ########################################################################
-find_package(SoapySDR NO_MODULE REQUIRED)
-
-set(SOAPY_SDR_UTIL_SOURCES
+add_executable(SoapySDRUtil
     SoapySDRUtil.cpp
     SoapySDRProbe.cpp
     SoapyRateTest.cpp
 )
-include_directories(${SoapySDR_INCLUDE_DIRS})
 if (MSVC)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/msvc)
+    target_include_directories(SoapySDRUtil PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/msvc)
 endif ()
-add_executable(SoapySDRUtil ${SOAPY_SDR_UTIL_SOURCES})
-target_link_libraries(SoapySDRUtil ${SoapySDR_LIBRARIES})
+target_link_libraries(SoapySDRUtil SoapySDR)
 install(TARGETS SoapySDRUtil DESTINATION bin)
 
 #install man pages for the application executable

--- a/cmake/Modules/SoapySDRConfig.cmake
+++ b/cmake/Modules/SoapySDRConfig.cmake
@@ -53,45 +53,6 @@ endif()
 set(LIB_SUFFIX ${LIB_SUFFIX} CACHE STRING "lib directory suffix")
 
 ########################################################################
-# Compiler settings used for core library, modules, applications
-########################################################################
-if(CMAKE_COMPILER_IS_GNUCXX)
-
-    #force a compile-time error when symbols are missing
-    list(APPEND SoapySDR_LINKER_FLAGS "-Wl,--no-undefined")
-
-    #common warnings to help encourage good coding practices
-    list(APPEND SoapySDR_COMPILE_OPTIONS -Wall)
-    list(APPEND SoapySDR_COMPILE_OPTIONS -Wextra)
-endif()
-
-if(APPLE)
-    #fixes issue with duplicate module registry when using application bundle
-    list(APPEND SoapySDR_LINKER_FLAGS "-flat_namespace")
-endif()
-
-if(MSVC)
-    #C++11 is a required language feature for this project
-    if (${MSVC_VERSION} LESS 1700)
-        message(FATAL_ERROR "the build requires MSVC 2012 or newer for C++11 support")
-    endif()
-
-    #we always want to use multiple cores for compilation
-    list(APPEND SoapySDR_COMPILE_OPTIONS /MP)
-
-    #suppress the following warnings which are commonly caused by project headers
-    list(APPEND SoapySDR_COMPILE_OPTIONS /wd4251) #disable 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
-    list(APPEND SoapySDR_COMPILE_OPTIONS /wd4503) #'identifier' : decorated name length exceeded, name was truncated
-
-    #projects should be cross-platform and standard stl functions should work
-    list(APPEND SoapySDR_COMPILE_DEFINITIONS -DNOMINMAX) #enables std::min and std::max
-endif()
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
-    list(APPEND SoapySDR_COMPILE_OPTIONS -stdlib=libc++)
-endif()
-
-########################################################################
 # extract the ABI version string from the Version.h header
 ########################################################################
 function(_SOAPY_SDR_GET_ABI_VERSION VERSION SOAPY_SDR_INCLUDE_DIR)
@@ -117,49 +78,10 @@ if (SOAPY_SDR_IN_TREE_SOURCE_DIR)
 endif (SOAPY_SDR_IN_TREE_SOURCE_DIR)
 
 ########################################################################
-## installation root
-########################################################################
-if (UNIX)
-    get_filename_component(SOAPY_SDR_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
-elseif (WIN32)
-    get_filename_component(SOAPY_SDR_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
-endif ()
-
-########################################################################
-## locate the library
-########################################################################
-find_library(
-    SOAPY_SDR_LIBRARY SoapySDR SoapySDRd
-    PATHS ${SOAPY_SDR_ROOT}/lib${LIB_SUFFIX}
-    PATH_SUFFIXES ${CMAKE_LIBRARY_ARCHITECTURE}
-    NO_DEFAULT_PATH
-)
-if(NOT SOAPY_SDR_LIBRARY)
-    message(FATAL_ERROR "cannot find SoapySDR library in ${SOAPY_SDR_ROOT}/lib${LIB_SUFFIX}")
-endif()
-set(SoapySDR_LIBRARIES SoapySDR)
-
-########################################################################
-## locate the includes
-########################################################################
-find_path(
-    SOAPY_SDR_INCLUDE_DIR SoapySDR/Config.hpp
-    PATHS ${SOAPY_SDR_ROOT}/include
-    NO_DEFAULT_PATH
-)
-if(NOT SOAPY_SDR_INCLUDE_DIR)
-    message(FATAL_ERROR "cannot find SoapySDR includes in ${SOAPY_SDR_ROOT}/include")
-endif()
-set(SoapySDR_INCLUDE_DIRS ${SOAPY_SDR_INCLUDE_DIR})
-_SOAPY_SDR_GET_ABI_VERSION(SOAPY_SDR_ABI_VERSION ${SoapySDR_INCLUDE_DIRS})
-
-########################################################################
 ## create import library target
 ########################################################################
-add_library(SoapySDR SHARED IMPORTED)
-set_property(TARGET SoapySDR PROPERTY IMPORTED_LOCATION ${SOAPY_SDR_LIBRARY})
-set_property(TARGET SoapySDR PROPERTY IMPORTED_IMPLIB ${SOAPY_SDR_LIBRARY})
-set_property(TARGET SoapySDR PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SOAPY_SDR_INCLUDE_DIR})
-set_property(TARGET SoapySDR PROPERTY INTERFACE_COMPILE_OPTIONS ${SoapySDR_COMPILE_OPTIONS})
-set_property(TARGET SoapySDR PROPERTY INTERFACE_COMPILE_DEFINITIONS ${SoapySDR_COMPILE_DEFINITIONS})
-set_property(TARGET SoapySDR PROPERTY INTERFACE_LINK_LIBRARIES ${SoapySDR_LINKER_FLAGS})
+include(SoapySDRExport)
+
+#set old-style variables: used in python swig flags and misc projects
+get_target_property(SoapySDR_INCLUDE_DIRS SoapySDR INTERFACE_INCLUDE_DIRECTORIES)
+set(SoapySDR_LIBRARIES SoapySDR)

--- a/cmake/Modules/SoapySDRUtil.cmake
+++ b/cmake/Modules/SoapySDRUtil.cmake
@@ -88,10 +88,11 @@ function(SOAPY_SDR_MODULE_UTIL)
         list(APPEND MODULE_SOURCES "${version_file}")
     endif()
 
-    include_directories(${SoapySDR_INCLUDE_DIRS})
     add_library(${MODULE_TARGET} MODULE ${MODULE_SOURCES})
-    target_link_libraries(${MODULE_TARGET} ${MODULE_LIBRARIES} ${SoapySDR_LIBRARIES})
+    target_include_directories(${MODULE_TARGET} PRIVATE SoapySDR)
+    target_link_libraries(${MODULE_TARGET} ${MODULE_LIBRARIES} SoapySDR)
     set_target_properties(${MODULE_TARGET} PROPERTIES DEBUG_POSTFIX "") #same name in debug mode
+    set_property(TARGET ${MODULE_TARGET} PROPERTY CXX_STANDARD 11)
 
     if (NOT MODULE_DESTINATION)
         set(MODULE_DESTINATION lib${LIB_SUFFIX}/SoapySDR/modules${SOAPY_SDR_ABI_VERSION}/)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(SoapySDR SHARED
 )
 target_link_libraries(SoapySDR PUBLIC ${SoapySDR_LINKER_FLAGS})
 target_include_directories(SoapySDR PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(SoapySDR PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(SoapySDR PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_compile_options(SoapySDR PUBLIC ${SoapySDR_COMPILE_OPTIONS})
 target_compile_definitions(SoapySDR PUBLIC ${SoapySDR_COMPILE_DEFINITIONS})
 set_target_properties(SoapySDR PROPERTIES SOVERSION ${SOAPY_SDR_ABI_VERSION})
@@ -68,13 +68,40 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     #symbols are only exported from libraries/modules explicitly
     target_compile_options(SoapySDR PRIVATE -fvisibility=hidden)
     target_compile_options(SoapySDR PRIVATE -fvisibility-inlines-hidden)
+
+    #force a compile-time error when symbols are missing
+    #otherwise modules will cause a runtime error on load
+    target_link_libraries(SoapySDR PUBLIC "-Wl,--no-undefined")
+
+    #common warnings to help encourage good coding practices
+    target_compile_options(SoapySDR PUBLIC -Wall)
+    target_compile_options(SoapySDR PUBLIC -Wextra)
 endif()
 
-#disable MSVC warnings
 if (MSVC)
+    #we always want to use multiple cores for compilation
+    target_compile_options(SoapySDR PUBLIC /MP)
+
+    #disable MSVC warnings
     target_compile_definitions(SoapySDR PRIVATE -D_CRT_NONSTDC_NO_DEPRECATE) #strdup
     target_compile_definitions(SoapySDR PRIVATE -D_CRT_SECURE_NO_WARNINGS) #strncpy
+
+    #disable MSVC warnings that come from public API
+    target_compile_options(SoapySDR PUBLIC /wd4251) #disable 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+    target_compile_options(SoapySDR PUBLIC /wd4503) #'identifier' : decorated name length exceeded, name was truncated
+
+    #projects should be cross-platform and standard stl functions should work
+    target_compile_definitions(SoapySDR PUBLIC -DNOMINMAX) #enables std::min and std::max
 endif ()
+
+if(APPLE)
+    #fixes issue with duplicate module registry when using application bundle
+    target_link_libraries(SoapySDR PUBLIC "-flat_namespace")
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+    target_compile_options(SoapySDR PUBLIC -stdlib=libc++)
+endif()
 
 ########################################################################
 # Configure sources
@@ -98,10 +125,14 @@ target_sources(SoapySDR PRIVATE
 # Install the library
 ########################################################################
 install(TARGETS SoapySDR
+    EXPORT SoapySDRExport
     LIBRARY DESTINATION lib${LIB_SUFFIX} # .so file
     ARCHIVE DESTINATION lib${LIB_SUFFIX} # .lib file
     RUNTIME DESTINATION bin              # .dll file
 )
+
+#export target to SoapySDR project config
+install(EXPORT SoapySDRExport DESTINATION ${CMAKE_LIB_DEST})
 
 ########################################################################
 # Build pkg config file

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,9 +10,9 @@ if (NOT ENABLE_LIBRARY)
 endif()
 
 ########################################################################
-# Soapy SDR sources and dependencies
+# Setup the library
 ########################################################################
-list(APPEND SOAPY_SDR_SOURCES
+add_library(SoapySDR SHARED
     Device.cpp
     Factory.cpp
     Registry.cpp
@@ -23,12 +23,34 @@ list(APPEND SOAPY_SDR_SOURCES
     Formats.cpp
     ConverterRegistry.cpp
     DefaultConverters.cpp
+    #C API support sources
+    TypesC.cpp
+    ModulesC.cpp
+    VersionC.cpp
+    DeviceC.cpp
+    FactoryC.cpp
+    LoggerC.cpp
+    TimeC.cpp
+    ErrorsC.cpp
+    FormatsC.cpp
 )
+target_link_libraries(SoapySDR PUBLIC ${SoapySDR_LINKER_FLAGS})
+target_include_directories(SoapySDR PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(SoapySDR PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_compile_options(SoapySDR PUBLIC ${SoapySDR_COMPILE_OPTIONS})
+target_compile_definitions(SoapySDR PUBLIC ${SoapySDR_COMPILE_DEFINITIONS})
+set_target_properties(SoapySDR PROPERTIES SOVERSION ${SOAPY_SDR_ABI_VERSION})
+set_target_properties(SoapySDR PROPERTIES VERSION ${SOAPY_SDR_LIBVER})
+set_target_properties(SoapySDR PROPERTIES DEFINE_SYMBOL "SOAPY_SDR_DLL_EXPORTS")
+
+########################################################################
+# compiler specifics
+########################################################################
 
 #dl libs used by dlopen in unix
-list(APPEND SOAPY_SDR_LIBRARIES
-    ${CMAKE_DL_LIBS}
-)
+if (CMAKE_DL_LIBS)
+    target_link_libraries(SoapySDR PRIVATE ${CMAKE_DL_LIBS})
+endif (CMAKE_DL_LIBS)
 
 if (WIN32)
     set(MODULE_EXT "dll")
@@ -41,55 +63,36 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
     #support threaded client code
     #notice that -pthread is not the same as -lpthread
-    list(APPEND SOAPY_SDR_LIBRARIES -pthread)
+    target_link_libraries(SoapySDR PRIVATE -pthread)
 
     #symbols are only exported from libraries/modules explicitly
-    add_compile_options(-fvisibility=hidden)
-    add_compile_options(-fvisibility-inlines-hidden)
+    target_compile_options(SoapySDR PRIVATE -fvisibility=hidden)
+    target_compile_options(SoapySDR PRIVATE -fvisibility-inlines-hidden)
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
+#disable MSVC warnings
+if (MSVC)
+    target_compile_definitions(SoapySDR PRIVATE -D_CRT_NONSTDC_NO_DEPRECATE) #strdup
+    target_compile_definitions(SoapySDR PRIVATE -D_CRT_SECURE_NO_WARNINGS) #strncpy
+endif ()
 
-list(APPEND SOAPY_SDR_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/Modules.cpp)
+########################################################################
+# Configure sources
+########################################################################
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/Modules.in.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/Modules.cpp
 @ONLY)
 
-list(APPEND SOAPY_SDR_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp)
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/Version.in.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp
 @ONLY)
 
-#C API support sources
-list(APPEND SOAPY_SDR_SOURCES
-    TypesC.cpp
-    ModulesC.cpp
-    VersionC.cpp
-    DeviceC.cpp
-    FactoryC.cpp
-    LoggerC.cpp
-    TimeC.cpp
-    ErrorsC.cpp
-    FormatsC.cpp
+target_sources(SoapySDR PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}/Modules.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp
 )
-
-#disable MSVC warnings
-if (MSVC)
-    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
-endif ()
-
-########################################################################
-# Build the library
-########################################################################
-add_library(SoapySDR SHARED ${SOAPY_SDR_SOURCES})
-if (SOAPY_SDR_LIBRARIES)
-    target_link_libraries(SoapySDR ${SOAPY_SDR_LIBRARIES})
-endif()
-set_target_properties(SoapySDR PROPERTIES SOVERSION ${SOAPY_SDR_ABI_VERSION})
-set_target_properties(SoapySDR PROPERTIES VERSION ${SOAPY_SDR_LIBVER})
-set_target_properties(SoapySDR PROPERTIES DEFINE_SYMBOL "SOAPY_SDR_DLL_EXPORTS")
 
 ########################################################################
 # Install the library

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 2.8)
 project(SoapySDRPython CXX)
 enable_testing()
 
-find_package(SoapySDR NO_MODULE REQUIRED)
+find_package(SoapySDR CONFIG REQUIRED)
 
 ########################################################################
 # Find SWIG
@@ -88,7 +88,7 @@ endif()
 ########################################################################
 ## set the swig flags - shared with python3 build
 ########################################################################
-set(CMAKE_SWIG_FLAGS -c++ -threads)
+set(CMAKE_SWIG_FLAGS -c++ -threads -I${SoapySDR_INCLUDE_DIRS})
 
 #check for size_t issue on arm 32-bit platforms
 include(CheckCXXSourceCompiles)
@@ -145,8 +145,6 @@ endif()
 # Build Module
 ########################################################################
 include(UseSWIG)
-include_directories(${SoapySDR_INCLUDE_DIRS})
-include_directories(${PYTHON_INCLUDE_DIRS})
 
 message(STATUS "CMAKE_SWIG_FLAGS=${CMAKE_SWIG_FLAGS}")
 set_source_files_properties(SoapySDR.i PROPERTIES CPLUSPLUS ON)
@@ -157,7 +155,8 @@ else()
 SWIG_ADD_LIBRARY(SoapySDR LANGUAGE python SOURCES SoapySDR.i)
 endif()
 
-SWIG_LINK_LIBRARIES(SoapySDR ${SoapySDR_LIBRARIES} ${PYTHON_LIBRARIES})
+target_include_directories(${SWIG_MODULE_SoapySDR_REAL_NAME} PRIVATE ${PYTHON_INCLUDE_DIRS})
+SWIG_LINK_LIBRARIES(SoapySDR SoapySDR ${PYTHON_LIBRARIES})
 
 ########################################################################
 # Install Module

--- a/python3/CMakeLists.txt
+++ b/python3/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Feature setup
 ########################################################################
-find_package(SoapySDR NO_MODULE REQUIRED)
+find_package(SoapySDR CONFIG REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
 ########################################################################
@@ -60,8 +60,6 @@ endif()
 # Build Module
 ########################################################################
 include(UseSWIG)
-include_directories(${SoapySDR_INCLUDE_DIRS})
-include_directories(${PYTHON3_INCLUDE_DIRS})
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/../python/SoapySDR.i
@@ -77,7 +75,8 @@ else()
 SWIG_ADD_LIBRARY(SoapySDR3 LANGUAGE python SOURCES ${CMAKE_CURRENT_BINARY_DIR}/SoapySDR.i)
 endif()
 
-SWIG_LINK_LIBRARIES(SoapySDR3 ${SoapySDR_LIBRARIES} ${PYTHON3_LIBRARIES})
+target_include_directories(${SWIG_MODULE_SoapySDR3_REAL_NAME} PRIVATE ${PYTHON3_INCLUDE_DIRS})
+SWIG_LINK_LIBRARIES(SoapySDR3 SoapySDR ${PYTHON3_LIBRARIES})
 
 set_target_properties(${SWIG_MODULE_SoapySDR3_REAL_NAME} PROPERTIES OUTPUT_NAME _SoapySDR)
 


### PR DESCRIPTION
* encapsulated include/linker/flags on targets
* project config exports a target (just link to SoapySDR)
* Resolves https://github.com/pothosware/SoapySDR/issues/152
* moved cmake requirements up to v3