### PR TITLE
Provide Python registerLogHandler() support

### DIFF
--- a/include/SoapySDR/Logger.h
+++ b/include/SoapySDR/Logger.h
@@ -82,6 +82,7 @@ typedef void (*SoapySDRLogHandler)(const SoapySDRLogLevel logLevel, const char *
 /*!
  * Register a new system log handler.
  * Platforms should call this to replace the default stdio handler.
+ * Passing `NULL` restores the default.
  */
 SOAPY_SDR_API void SoapySDR_registerLogHandler(const SoapySDRLogHandler handler);
 

--- a/include/SoapySDR/Logger.hpp
+++ b/include/SoapySDR/Logger.hpp
@@ -56,6 +56,7 @@ typedef SoapySDRLogHandler LogHandler;
 /*!
  * Register a new system log handler.
  * Platforms should call this to replace the default stdio handler.
+ * Passing `nullptr` restores the default.
  */
 SOAPY_SDR_API void registerLogHandler(const LogHandler &handler);
 

--- a/lib/LoggerC.cpp
+++ b/lib/LoggerC.cpp
@@ -65,7 +65,7 @@ int vasprintf(char **strp, const char *fmt, va_list ap)
 /***********************************************************************
  * Default log message handler implementation
  **********************************************************************/
-void defaultLogHandler(const SoapySDRLogLevel logLevel, const char *message)
+static void defaultLogHandler(const SoapySDRLogLevel logLevel, const char *message)
 {
     switch (logLevel)
     {
@@ -103,9 +103,17 @@ void SoapySDR_vlogf(const SoapySDRLogLevel logLevel, const char *format, va_list
     }
 }
 
+/***********************************************************************
+ * Replace the current registeredLogHandler with handler.
+ * If nullptr is passed then the default log handler is restored.
+ **********************************************************************/
 void SoapySDR_registerLogHandler(const SoapySDRLogHandler handler)
 {
-    registeredLogHandler = handler;
+    if (handler) {
+        registeredLogHandler = handler;
+    } else {
+        registeredLogHandler = defaultLogHandler;
+    }
 }
 
 void SoapySDR_setLogLevel(const SoapySDRLogLevel logLevel)

--- a/python/SoapySDR.i
+++ b/python/SoapySDR.i
@@ -22,9 +22,14 @@
 ////////////////////////////////////////////////////////////////////////
 %include <exception.i>
 
+// We only expect to throw DirectorExceptions from within
+// SoapySDR_pythonLogHandlerBase calls.  Catching them permits us to
+// propagate exceptions thrown in the Python log handler callback back to
+// Python.
 %exception
 {
     try{$action}
+    catch (Swig::DirectorException &e) { SWIG_fail; }
     catch (const std::exception &ex)
     {SWIG_exception(SWIG_RuntimeError, ex.what());}
     catch (...)
@@ -128,6 +133,13 @@
 %ignore SoapySDR::registerLogHandler;
 %include <SoapySDR/Logger.h>
 %include <SoapySDR/Logger.hpp>
+
+%feature("director:except") {
+    if ($error != NULL) {
+        throw Swig::DirectorMethodException("DAVE");
+    }
+}
+
 
 %feature("director") SoapySDR_pythonLogHandlerBase;
 

--- a/python/SoapySDR.i
+++ b/python/SoapySDR.i
@@ -155,6 +155,8 @@
         virtual ~SoapySDR_pythonLogHandlerBase(void)
         {
             globalHandle = nullptr;
+            // Restore the default, C coded, log handler.
+            SoapySDR::registerLogHandler(nullptr);
         }
         virtual void handle(const SoapySDR::LogLevel, const char *) = 0;
 
@@ -184,7 +186,10 @@ class SoapySDR_pythonLogHandler(SoapySDR_pythonLogHandlerBase):
     def handle(self, *args): self.handler(*args)
 
 def registerLogHandler(h):
-    SoapySDR_globalLogHandlers[0] = SoapySDR_pythonLogHandler(h)
+    if h is None:
+        SoapySDR_globalLogHandlers[0] = None
+    else:
+        SoapySDR_globalLogHandlers[0] = SoapySDR_pythonLogHandler(h)
 %}
 
 ////////////////////////////////////////////////////////////////////////

--- a/python/SoapySDR.i
+++ b/python/SoapySDR.i
@@ -29,7 +29,7 @@
 %exception
 {
     try{$action}
-    catch (Swig::DirectorException &e) { SWIG_fail; }
+    catch (const Swig::DirectorException &e) { SWIG_fail; }
     catch (const std::exception &ex)
     {SWIG_exception(SWIG_RuntimeError, ex.what());}
     catch (...)
@@ -136,7 +136,7 @@
 
 %feature("director:except") {
     if ($error != NULL) {
-        throw Swig::DirectorMethodException("DAVE");
+        throw Swig::DirectorMethodException();
     }
 }
 


### PR DESCRIPTION
This extends the ability to set a log message handler, present in the C/C++ API, to the Python API.  The motivation is to provide a means for Python code to be aware of fault conditions that don't trigger the return of an error code or the throwing of an exception.  An example of such a fault is a failure to calibrate the SDR.  See issue #201.

In addition, the default log handler can now be restored from both APIs by passing `None`/`nullptr` to `registerLogHandler()`.