### PR TITLE
Python examples

### DIFF
--- a/python/apps/MeasureDelay.py
+++ b/python/apps/MeasureDelay.py
@@ -8,130 +8,135 @@ import os
 import time
 
 import numpy as np
-from scipy import signal
 
 import SoapySDR
-from SoapySDR import * #SOAPY_SDR_ constants
-
 import soapy_log_handle
 
-def generate_cf32_pulse(numSamps, width=5, scaleFactor=0.3):
-    x = np.linspace(-width, width, numSamps)
-    pulse = np.sinc(x).astype(np.complex64)
-    return pulse*scaleFactor
+RX_DIR, TX_DIR = SoapySDR.SOAPY_SDR_RX, SoapySDR.SOAPY_SDR_TX
+
+def generate_cf32_pulse(num_samps, width=5, scale_factor=0.3):
+    """Create a sinc pulse."""
+    rel_time = np.linspace(-width, width, num_samps)
+    pulse = np.sinc(rel_time).astype(np.complex64)
+    return pulse * scale_factor
 
 def measure_delay(
-    args,
-    rate,
-    freq=None,
-    rxBw=None,
-    txBw=None,
-    rxChan=0,
-    txChan=0,
-    rxAnt=None,
-    txAnt=None,
-    rxGain=None,
-    txGain=None,
-    clockRate=None,
-    numTxSamps=200,
-    numRxSamps=10000,
-    dumpDir=None,
+        args,
+        rate,
+        freq=None,
+        rx_bw=None,
+        tx_bw=None,
+        rx_chan=0,
+        tx_chan=0,
+        rx_ant=None,
+        tx_ant=None,
+        rx_gain=None,
+        tx_gain=None,
+        clock_rate=None,
+        num_tx_samps=200,
+        num_rx_samps=10000,
+        dump_dir=None,
 ):
+    """Transmit a bandlimited pulse, receive it and find the delay."""
+
     sdr = SoapySDR.Device(args)
     if not sdr.hasHardwareTime():
         raise Exception('this device does not support timed streaming')
 
     #set clock rate first
-    if clockRate is not None: sdr.setMasterClockRate(clockRate)
+    if clock_rate is not None:
+        sdr.setMasterClockRate(clock_rate)
 
     #set sample rate
-    sdr.setSampleRate(SOAPY_SDR_RX, rxChan, rate)
-    sdr.setSampleRate(SOAPY_SDR_TX, txChan, rate)
-    print("Actual Rx Rate %f Msps"%(sdr.getSampleRate(SOAPY_SDR_RX, rxChan) / 1e6))
-    print("Actual Tx Rate %f Msps"%(sdr.getSampleRate(SOAPY_SDR_TX, txChan) / 1e6))
+    sdr.setSampleRate(RX_DIR, rx_chan, rate)
+    sdr.setSampleRate(TX_DIR, tx_chan, rate)
+    print("Actual Rx Rate %f Msps"%(sdr.getSampleRate(RX_DIR, rx_chan) / 1e6))
+    print("Actual Tx Rate %f Msps"%(sdr.getSampleRate(TX_DIR, tx_chan) / 1e6))
 
     #set antenna
-    if rxAnt is not None:
-        sdr.setAntenna(SOAPY_SDR_RX, rxChan, rxAnt)
-    if txAnt is not None:
-        sdr.setAntenna(SOAPY_SDR_TX, txChan, txAnt)
+    if rx_ant is not None:
+        sdr.setAntenna(RX_DIR, rx_chan, rx_ant)
+    if tx_ant is not None:
+        sdr.setAntenna(TX_DIR, tx_chan, tx_ant)
 
     #set overall gain
-    if rxGain is not None:
-        sdr.setGain(SOAPY_SDR_RX, rxChan, rxGain)
-    if txGain is not None:
-        sdr.setGain(SOAPY_SDR_TX, txChan, txGain)
+    if rx_gain is not None:
+        sdr.setGain(RX_DIR, rx_chan, rx_gain)
+    if tx_gain is not None:
+        sdr.setGain(TX_DIR, tx_chan, tx_gain)
 
     #tune frontends
     if freq is not None:
-        sdr.setFrequency(SOAPY_SDR_RX, rxChan, freq)
+        sdr.setFrequency(RX_DIR, rx_chan, freq)
     if freq is not None:
-        sdr.setFrequency(SOAPY_SDR_TX, txChan, freq)
+        sdr.setFrequency(TX_DIR, tx_chan, freq)
 
     #set bandwidth
-    if rxBw is not None:
-        sdr.setBandwidth(SOAPY_SDR_RX, rxChan, rxBw)
-    if txBw is not None:
-        sdr.setBandwidth(SOAPY_SDR_TX, txChan, txBw)
+    if rx_bw is not None:
+        sdr.setBandwidth(RX_DIR, rx_chan, rx_bw)
+    if tx_bw is not None:
+        sdr.setBandwidth(TX_DIR, tx_chan, tx_bw)
 
     #create rx and tx streams
     print("Create Rx and Tx streams")
-    rxStream = sdr.setupStream(SOAPY_SDR_RX, "CF32", [rxChan])
-    txStream = sdr.setupStream(SOAPY_SDR_TX, "CF32", [txChan])
+    rx_stream = sdr.setupStream(RX_DIR, "CF32", [rx_chan])
+    tx_stream = sdr.setupStream(TX_DIR, "CF32", [tx_chan])
 
     #let things settle
     time.sleep(1)
 
     #transmit a pulse in the near future
-    sdr.activateStream(txStream)
-    txPulse = generate_cf32_pulse(numTxSamps)
-    txTime0 = int(sdr.getHardwareTime() + 0.1e9) #100ms
-    txFlags = SOAPY_SDR_HAS_TIME | SOAPY_SDR_END_BURST
-    sr = sdr.writeStream(txStream, [txPulse], len(txPulse), txFlags, txTime0)
-    if sr.ret != len(txPulse):
-        raise Exception('transmit failed %s'%str(sr))
+    sdr.activateStream(tx_stream)
+    tx_pulse = generate_cf32_pulse(num_tx_samps)
+    tx_time_0 = int(sdr.getHardwareTime() + 0.1e9) #100ms
+    tx_flags = SoapySDR.SOAPY_SDR_HAS_TIME | SoapySDR.SOAPY_SDR_END_BURST
+    status = sdr.writeStream(tx_stream, [tx_pulse], len(tx_pulse), tx_flags, tx_time_0)
+    if status.ret != len(tx_pulse):
+        raise Exception('transmit failed %s'%str(status))
 
     #receive slightly before transmit time
-    rxBuffs = np.array([], np.complex64)
-    rxFlags = SOAPY_SDR_HAS_TIME | SOAPY_SDR_END_BURST
+    rx_buffs = np.array([], np.complex64)
+    rx_flags = SoapySDR.SOAPY_SDR_HAS_TIME | SoapySDR.SOAPY_SDR_END_BURST
     #half of the samples come before the transmit time
-    receiveTime = int(txTime0 - (numRxSamps/rate) * 1e9 / 2)
-    sdr.activateStream(rxStream, rxFlags, receiveTime, numRxSamps)
-    rxTime0 = None
+    receive_time = int(tx_time_0 - (num_rx_samps/rate) * 1e9 / 2)
+    sdr.activateStream(rx_stream, rx_flags, receive_time, num_rx_samps)
+    rx_time_0 = None
 
     #accumulate receive buffer into large contiguous buffer
     while True:
-        rxBuff = np.array([0]*1024, np.complex64)
-        timeoutUs = int(5e5) #500 ms >> stream time
-        sr = sdr.readStream(rxStream, [rxBuff], len(rxBuff), timeoutUs=timeoutUs)
+        rx_buff = np.array([0]*1024, np.complex64)
+        timeout_us = int(5e5) #500 ms >> stream time
+        status = sdr.readStream(rx_stream, [rx_buff], len(rx_buff), timeout_us=timeout_us)
 
         #stash time on first buffer
-        if sr.ret > 0 and len(rxBuffs) == 0:
-            rxTime0 = sr.timeNs
-            if (sr.flags & SOAPY_SDR_HAS_TIME) == 0:
-                raise Exception('receive fail - no timestamp on first readStream %s'%(str(sr)))
+        if status.ret > 0 and not rx_buffs.empty():
+            rx_time_0 = status.timeNs
+            if (status.flags & SoapySDR.SOAPY_SDR_HAS_TIME) == 0:
+                raise Exception('receive fail - no timestamp on first readStream %s'%(str(status)))
 
         #accumulate buffer or exit loop
-        if sr.ret > 0:
-            rxBuffs = np.concatenate((rxBuffs, rxBuff[:sr.ret]))
+        if status.ret > 0:
+            rx_buffs = np.concatenate((rx_buffs, rx_buff[:status.ret]))
         else:
             break
 
     #cleanup streams
     print("Cleanup streams")
-    sdr.deactivateStream(txStream)
-    sdr.closeStream(rxStream)
-    sdr.closeStream(txStream)
+    sdr.deactivateStream(tx_stream)
+    sdr.closeStream(rx_stream)
+    sdr.closeStream(tx_stream)
 
     #check resulting buffer
-    if len(rxBuffs) != numRxSamps:
-        raise Exception('receive fail - captured samples %d out of %d'%(len(rxBuffs), numRxSamps))
-    if rxTime0 is None:
+    if len(rx_buffs) != num_rx_samps:
+        raise Exception(
+            'receive fail - captured samples %d out of %d'%(len(rx_buffs), num_rx_samps))
+    if rx_time_0 is None:
         raise Exception('receive fail - no valid timestamp')
 
     #clear initial samples because transients
-    rxMean = np.mean(rxBuffs)
-    for i in range(len(rxBuffs) // 100): rxBuffs[i] = rxMean
+    rx_mean = np.mean(rx_buffs)
+    for i in range(len(rx_buffs) // 100):
+        rx_buffs[i] = rx_mean
 
     #normalize the samples
     def normalize(samps):
@@ -141,33 +146,36 @@ def measure_delay(
         #print samps[:100]
         return samps
 
-    txPulseNorm = normalize(txPulse)
-    rxBuffsNorm = normalize(rxBuffs)
+    tx_pulse_norm = normalize(tx_pulse)
+    rx_buffs_norm = normalize(rx_buffs)
 
     #dump debug samples
-    if dumpDir is not None:
-        np.save(os.path.join(dumpDir, 'txNorm.npy'), txPulseNorm)
-        np.save(os.path.join(dumpDir, 'rxNorm.npy'), rxBuffsNorm)
-        np.save(os.path.join(dumpDir, 'rxRawI.npy'), np.real(rxBuffs))
-        np.save(os.path.join(dumpDir, 'rxRawQ.npy'), np.imag(rxBuffs))
+    if dump_dir is not None:
+        np.save(os.path.join(dump_dir, 'txNorm.npy'), tx_pulse_norm)
+        np.save(os.path.join(dump_dir, 'rxNorm.npy'), rx_buffs_norm)
+        np.save(os.path.join(dump_dir, 'rxRawI.npy'), np.real(rx_buffs))
+        np.save(os.path.join(dump_dir, 'rxRawQ.npy'), np.imag(rx_buffs))
 
     #look for the for peak index for time offsets
-    rxArgmaxIndex = np.argmax(rxBuffsNorm)
-    txArgmaxIndex = np.argmax(txPulseNorm)
+    rx_argmax_index = np.argmax(rx_buffs_norm)
+    tx_argmax_index = np.argmax(tx_pulse_norm)
 
     #check goodness of peak by comparing argmax and correlation
-    rxCoorIndex = np.argmax(np.correlate(rxBuffsNorm, txPulseNorm)) + len(txPulseNorm) // 2
-    if abs(rxCoorIndex-rxArgmaxIndex) > len(txPulseNorm)/4:
-        raise Exception('correlation(%d) does not match argmax(%d), probably bad data'%(rxCoorIndex, rxArgmaxIndex))
+    rx_coor_index = np.argmax(np.correlate(rx_buffs_norm, tx_pulse_norm)) + len(tx_pulse_norm) // 2
+    if abs(rx_coor_index-rx_argmax_index) > len(tx_pulse_norm)/4:
+        raise Exception(
+            'correlation(%d) does not match argmax(%d), probably bad data' %
+            (rx_coor_index, rx_argmax_index))
 
     #calculate time offset
-    txPeakTime = int(txTime0 + (txArgmaxIndex / rate) * 1e9)
-    rxPeakTime = int(rxTime0 + (rxArgmaxIndex / rate) * 1e9)
-    timeDelta = rxPeakTime - txPeakTime
-    print('>>> Time delta %f us'%(timeDelta / 1e3))
+    tx_peak_time = int(tx_time_0 + (tx_argmax_index / rate) * 1e9)
+    rx_peak_time = int(rx_time_0 + (rx_argmax_index / rate) * 1e9)
+    time_delta = rx_peak_time - tx_peak_time
+    print('>>> Time delta %f us'%(time_delta / 1e3))
     print("Done!")
 
 def main():
+    """Parse command line arguments and perform measurement."""
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -185,32 +193,34 @@ def main():
     parser.add_argument("--clock-rate", type=float, help="Optional clock rate (Hz)")
     parser.add_argument("--dump-dir", type=str, help="Optional directory to dump debug samples")
     parser.add_argument("--debug", action='store_true', help="Output debug messages")
-    parser.add_argument("--abort-on-error", action='store_true', help="Halts operations if the SDR logs an error")
+    parser.add_argument(
+        "--abort-on-error", action='store_true',
+        help="Halts operations if the SDR logs an error")
 
     options = parser.parse_args()
 
     if options.abort_on_error:
-        exception_level=SOAPY_SDR_ERROR
+        exception_level = SoapySDR.SOAPY_SDR_ERROR
     else:
-        exception_level=None
+        exception_level = None
     soapy_log_handle.set_python_log_handler(exception_level=exception_level)
     if options.debug:
-        SoapySDR.setLogLevel(SOAPY_SDR_DEBUG)
+        SoapySDR.setLogLevel(SoapySDR.SOAPY_SDR_DEBUG)
 
     measure_delay(
         args=options.args,
         rate=options.rate,
         freq=options.freq,
-        rxBw=options.rx_bw,
-        txBw=options.tx_bw,
-        rxAnt=options.rx_ant,
-        txAnt=options.tx_ant,
-        rxGain=options.rx_gain,
-        txGain=options.tx_gain,
-        rxChan=options.rx_chan,
-        txChan=options.tx_chan,
-        clockRate=options.clock_rate,
-        dumpDir=options.dump_dir,
+        rx_bw=options.rx_bw,
+        tx_bw=options.tx_bw,
+        rx_ant=options.rx_ant,
+        tx_ant=options.tx_ant,
+        rx_gain=options.rx_gain,
+        tx_gain=options.tx_gain,
+        rx_chan=options.rx_chan,
+        tx_chan=options.tx_chan,
+        clock_rate=options.clock_rate,
+        dump_dir=options.dump_dir,
     )
 
 if __name__ == '__main__':

--- a/python/apps/MeasureDelay.py
+++ b/python/apps/MeasureDelay.py
@@ -13,6 +13,7 @@ from scipy import signal
 import SoapySDR
 from SoapySDR import * #SOAPY_SDR_ constants
 
+import soapy_log_handle
 
 def generate_cf32_pulse(numSamps, width=5, scaleFactor=0.3):
     x = np.linspace(-width, width, numSamps)
@@ -184,9 +185,15 @@ def main():
     parser.add_argument("--clock-rate", type=float, help="Optional clock rate (Hz)")
     parser.add_argument("--dump-dir", type=str, help="Optional directory to dump debug samples")
     parser.add_argument("--debug", action='store_true', help="Output debug messages")
+    parser.add_argument("--abort-on-error", action='store_true', help="Halts operations if the SDR logs an error")
 
     options = parser.parse_args()
 
+    if options.abort_on_error:
+        exception_level=SOAPY_SDR_ERROR
+    else:
+        exception_level=None
+    soapy_log_handle.set_python_log_handler(exception_level=exception_level)
     if options.debug:
         SoapySDR.setLogLevel(SOAPY_SDR_DEBUG)
 

--- a/python/apps/MeasureDelay.py
+++ b/python/apps/MeasureDelay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Measure round trip delay through RF loopback/leakage
 
 """

--- a/python/apps/MeasureDelay.py
+++ b/python/apps/MeasureDelay.py
@@ -106,10 +106,10 @@ def measure_delay(
     while True:
         rx_buff = np.array([0]*1024, np.complex64)
         timeout_us = int(5e5) #500 ms >> stream time
-        status = sdr.readStream(rx_stream, [rx_buff], len(rx_buff), timeout_us=timeout_us)
+        status = sdr.readStream(rx_stream, [rx_buff], len(rx_buff), timeoutUs=timeout_us)
 
         #stash time on first buffer
-        if status.ret > 0 and not rx_buffs.empty():
+        if status.ret > 0 and rx_buffs.size:
             rx_time_0 = status.timeNs
             if (status.flags & SoapySDR.SOAPY_SDR_HAS_TIME) == 0:
                 raise Exception('receive fail - no timestamp on first readStream %s'%(str(status)))

--- a/python/apps/SimpleSiggen.py
+++ b/python/apps/SimpleSiggen.py
@@ -20,13 +20,14 @@ from optparse import OptionParser
 import SoapySDR
 from SoapySDR import * #SOAPY_SDR_ constants
 
+import soapy_log_handle
+
 stop_running = False
 
 def signal_handler(signum, frame):
     global stop_running
     print('Signal handler called with signal {}'.format(signum))
     stop_running = True
-
 
 def siggen_app(
     args,
@@ -73,8 +74,7 @@ def siggen_app(
     if freq is not None:
         sdr.setFrequency(SOAPY_SDR_TX, txChan, freq)
 
-    #tx loop
-    #create tx stream
+
     print("Create Tx stream")
     txStream = sdr.setupStream(SOAPY_SDR_TX, "CF32", [txChan])
     print("Activate Tx Stream")
@@ -120,13 +120,19 @@ def main():
     parser.add_argument("--tx-gain", type=float, help="Optional Tx gain (dB)")
     parser.add_argument("--tx-chan", type=int, help="Transmitter channel (def=0)", default=0)
     parser.add_argument("--freq", type=float, help="Optional Tx and Rx freq (Hz)")
-    parser.add_argument("--tx-bw", type=float, help="Optional Tx filter bw (Hz)")
+    parser.add_argument("--tx-bw", type=float, help="Optional Tx filter bw (Hz)", default=5e6)
     parser.add_argument("--wave-freq", type=float, help="Baseband waveform freq (Hz)")
     parser.add_argument("--clock-rate", type=float, help="Optional clock rate (Hz)")
     parser.add_argument("--debug", action='store_true', help="Output debug messages")
+    parser.add_argument("--abort-on-error", action='store_true', help="Halts operations if the SDR logs an error")
 
     options = parser.parse_args()
 
+    if options.abort_on_error:
+        exception_level=SOAPY_SDR_WARNING
+    else:
+        exception_level=None
+    soapy_log_handle.set_python_log_handler(exception_level=exception_level)
     if options.debug:
         SoapySDR.setLogLevel(SOAPY_SDR_DEBUG)
 

--- a/python/apps/SimpleSiggen.py
+++ b/python/apps/SimpleSiggen.py
@@ -9,106 +9,112 @@ Terminate with cntl-C.
 
 import argparse
 import math
-import os
 import signal
 import time
 
 import numpy as np
 
-from optparse import OptionParser
 
 import SoapySDR
-from SoapySDR import * #SOAPY_SDR_ constants
+from SoapySDR import SOAPY_SDR_TX, SOAPY_SDR_DEBUG, SOAPY_SDR_WARNING
 
 import soapy_log_handle
 
-stop_running = False
 
-def signal_handler(signum, frame):
-    global stop_running
-    print('Signal handler called with signal {}'.format(signum))
-    stop_running = True
 
 def siggen_app(
-    args,
-    rate,
-    ampl=0.7,
-    freq=None,
-    txBw=None,
-    txChan=0,
-    txGain=None,
-    txAnt=None,
-    clockRate=None,
-    waveFreq=None
+        args,
+        rate,
+        ampl=0.7,
+        freq=None,
+        tx_bw=None,
+        tx_chan=0,
+        tx_gain=None,
+        tx_ant=None,
+        clock_rate=None,
+        wave_freq=None
 ):
-    global stop_running
+    """Generate signal until an interrupt signal is received."""
 
-    if waveFreq is None:
-        waveFreq = rate / 10
+    if wave_freq is None:
+        wave_freq = rate / 10
 
     sdr = SoapySDR.Device(args)
     #set clock rate first
-    if clockRate is not None:
-        sdr.setMasterClockRate(clockRate)
+    if clock_rate is not None:
+        sdr.setMasterclock_rate(clock_rate)
 
     #set sample rate
-    sdr.setSampleRate(SOAPY_SDR_TX, txChan, rate)
-    print("Actual Tx Rate %f Msps"%(sdr.getSampleRate(SOAPY_SDR_TX, txChan) / 1e6))
+    sdr.setSampleRate(SOAPY_SDR_TX, tx_chan, rate)
+    print("Actual Tx Rate %f Msps"%(sdr.getSampleRate(SOAPY_SDR_TX, tx_chan) / 1e6))
 
     #set bandwidth
-    if txBw is not None:
-        sdr.setBandwidth(SOAPY_SDR_TX, txChan, txBw)
+    if tx_bw is not None:
+        sdr.setBandwidth(SOAPY_SDR_TX, tx_chan, tx_bw)
 
     #set antenna
     print("Set the antenna")
-    if txAnt is not None:
-        sdr.setAntenna(SOAPY_SDR_TX, txChan, txAnt)
+    if tx_ant is not None:
+        sdr.setAntenna(SOAPY_SDR_TX, tx_chan, tx_ant)
 
     #set overall gain
     print("Set the gain")
-    if txGain is not None:
-        sdr.setGain(SOAPY_SDR_TX, txChan, txGain)
+    if tx_gain is not None:
+        sdr.setGain(SOAPY_SDR_TX, tx_chan, tx_gain)
 
     #tune frontends
     print("Tune the frontend")
     if freq is not None:
-        sdr.setFrequency(SOAPY_SDR_TX, txChan, freq)
+        sdr.setFrequency(SOAPY_SDR_TX, tx_chan, freq)
 
 
     print("Create Tx stream")
-    txStream = sdr.setupStream(SOAPY_SDR_TX, "CF32", [txChan])
+    tx_stream = sdr.setupStream(SOAPY_SDR_TX, "CF32", [tx_chan])
     print("Activate Tx Stream")
-    sdr.activateStream(txStream)
-    phaseAcc = 0
-    phaseInc = 2*math.pi*waveFreq/rate
-    streamMTU = sdr.getStreamMTU(txStream)
-    sampsCh0 = np.array([ampl]*streamMTU, np.complex64)
+    sdr.activateStream(tx_stream)
+    phase_acc = 0
+    phase_inc = 2*math.pi*wave_freq/rate
+    stream_mtu = sdr.getStreamMTU(tx_stream)
+    samps_chan = np.array([ampl]*stream_mtu, np.complex64)
 
-    timeLastPrint = time.time()
-    totalSamps = 0
-    while not stop_running:
-        phaseAccNext = phaseAcc + streamMTU*phaseInc
-        sampsCh0 = ampl*np.exp(1j * np.linspace(phaseAcc, phaseAccNext, streamMTU)).astype(np.complex64)
-        phaseAcc = phaseAccNext
-        while phaseAcc > math.pi * 2: phaseAcc -= math.pi * 2
+    time_last_print = time.time()
+    total_samps = 0
 
-        sr = sdr.writeStream(txStream, [sampsCh0], sampsCh0.size, timeoutUs=1000000)
-        if sr.ret != sampsCh0.size:
-            raise Exception("Expected writeStream() to consume all samples! %d"%sr.ret)
-        totalSamps += sr.ret
+    state = dict(running=True)
 
-        if time.time() > timeLastPrint + 5.0:
-            print("Python siggen rate: %f Msps"%(totalSamps / (time.time() - timeLastPrint) / 1e6))
-            totalSamps = 0
-            timeLastPrint = time.time()
+    def signal_handler(signum, _):
+        print('Signal handler called with signal {}'.format(signum))
+        state['running'] = False
+
+    signal.signal(signal.SIGINT, signal_handler)
+
+    while state['running']:
+        phase_acc_next = phase_acc + stream_mtu*phase_inc
+        phases = np.linspace(phase_acc, phase_acc_next, stream_mtu)
+        samps_chan = ampl*np.exp(1j * phases).astype(np.complex64)
+        phase_acc = phase_acc_next
+        while phase_acc > math.pi * 2:
+            phase_acc -= math.pi * 2
+
+        status = sdr.writeStream(tx_stream, [samps_chan], samps_chan.size, timeoutUs=1000000)
+        if status.ret != samps_chan.size:
+            raise Exception("Expected writeStream() to consume all samples! %d" % status.ret)
+        total_samps += status.ret
+
+        if time.time() > time_last_print + 5.0:
+            rate = total_samps / (time.time() - time_last_print) / 1e6
+            print("Python siggen rate: %f Msps" % rate)
+            total_samps = 0
+            time_last_print = time.time()
 
     #cleanup streams
     print("Cleanup stream")
-    sdr.deactivateStream(txStream)
-    sdr.closeStream(txStream)
+    sdr.deactivateStream(tx_stream)
+    sdr.closeStream(tx_stream)
     print("Done!")
 
 def main():
+    """Parse command line arguments and start sig-gen."""
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -124,31 +130,31 @@ def main():
     parser.add_argument("--wave-freq", type=float, help="Baseband waveform freq (Hz)")
     parser.add_argument("--clock-rate", type=float, help="Optional clock rate (Hz)")
     parser.add_argument("--debug", action='store_true', help="Output debug messages")
-    parser.add_argument("--abort-on-error", action='store_true', help="Halts operations if the SDR logs an error")
+    parser.add_argument(
+        "--abort-on-error", action='store_true',
+        help="Halts operations if the SDR logs an error")
 
     options = parser.parse_args()
 
     if options.abort_on_error:
-        exception_level=SOAPY_SDR_WARNING
+        exception_level = SOAPY_SDR_WARNING
     else:
-        exception_level=None
+        exception_level = None
     soapy_log_handle.set_python_log_handler(exception_level=exception_level)
     if options.debug:
         SoapySDR.setLogLevel(SOAPY_SDR_DEBUG)
-
-    signal.signal(signal.SIGINT, signal_handler)
 
     siggen_app(
         args=options.args,
         rate=options.rate,
         ampl=options.ampl,
         freq=options.freq,
-        txBw=options.tx_bw,
-        txAnt=options.tx_ant,
-        txGain=options.tx_gain,
-        txChan=options.tx_chan,
-        clockRate=options.clock_rate,
-        waveFreq=options.wave_freq,
+        tx_bw=options.tx_bw,
+        tx_ant=options.tx_ant,
+        tx_gain=options.tx_gain,
+        tx_chan=options.tx_chan,
+        clock_rate=options.clock_rate,
+        wave_freq=options.wave_freq,
     )
 
 if __name__ == '__main__':

--- a/python/apps/SimpleSiggen.py
+++ b/python/apps/SimpleSiggen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Simple signal generator for testing transmit
 
 Continuously output a carrier with single sideband sinusoid amplitude

--- a/python/apps/soapy_log_handle.py
+++ b/python/apps/soapy_log_handle.py
@@ -1,0 +1,41 @@
+"""Example Python basing logging for SoapySDR.
+
+This permits exceptions to be thrown if the log message is severe enough.
+"""
+from __future__ import print_function
+
+import sys
+import SoapySDR
+
+
+class SoapyException(Exception):
+    """SoapySDR has logged an error message (or worse)."""
+
+def set_python_log_handler(exception_level=None):
+    """Replace the default SoapySDR log handler with a Python one.
+
+    The python handler sends the log text to stderr.
+
+    If the log_level is at exception_level or worse then a SoapyException
+    is thrown.
+    """
+
+    log_level_text = {
+        SoapySDR.SOAPY_SDR_FATAL: "FATAL",
+        SoapySDR.SOAPY_SDR_CRITICAL: "CRITICAL",
+        SoapySDR.SOAPY_SDR_ERROR: "ERROR",
+        SoapySDR.SOAPY_SDR_WARNING: "WARNING",
+        SoapySDR.SOAPY_SDR_NOTICE: "NOTICE",
+        SoapySDR.SOAPY_SDR_INFO: "INFO",
+        SoapySDR.SOAPY_SDR_DEBUG: "DEBUG",
+        SoapySDR.SOAPY_SDR_TRACE: "TRACE",
+        SoapySDR.SOAPY_SDR_SSI: "SSI"}
+
+    def log_handler(log_level, message):
+        level_text = log_level_text[log_level]
+        log_text = "[{}] {}".format(level_text, message)
+        print(log_text, file=sys.stderr)
+        if exception_level is not None and log_level <= exception_level:
+            raise SoapyException(log_text)
+
+    SoapySDR.registerLogHandler(log_handler)


### PR DESCRIPTION
Update the two example Python applications

MeasureDelay.py and SimpleSiggen.py have been extended and updated.
- fix up integer handling (MeasureDelay.py failed to run under Python3)
- replace the deprecated optparse module with argparse
- replace numpy's tofile() calls with the platform independent numpy.save() 
- renamed command line options from camelCase to more conventional hyphen delimited style (e.g. "--txChan" to "--tx-chan")
- added --debug and --halt-on-error options
- use a python coded log handler function