### PR TITLE
Templated settings

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -827,7 +827,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       =  SoapySDR::Detail
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -1034,6 +1034,15 @@ public:
     virtual std::string readSensor(const std::string &key) const;
 
     /*!
+     * Readback a global sensor given the name.
+     * \tparam Type the return type for the sensor value
+     * \param key the ID name of an available sensor
+     * \return the current value of the sensor as the specified type
+     */
+    template <typename Type>
+    Type readSensor(const std::string &key) const;
+
+    /*!
      * List the available channel readback sensors.
      * A sensor can represent a reference lock, RSSI, temperature.
      * \param direction the channel direction RX or TX
@@ -1062,6 +1071,17 @@ public:
      * \return the current value of the sensor
      */
     virtual std::string readSensor(const int direction, const size_t channel, const std::string &key) const;
+
+    /*!
+     * Readback a channel sensor given the name.
+     * \tparam Type the return type for the sensor value
+     * \param direction the channel direction RX or TX
+     * \param channel an available channel on the device
+     * \param key the ID name of an available sensor
+     * \return the current value of the sensor as the specified type
+     */
+    template <typename Type>
+    Type readSensor(const int direction, const size_t channel, const std::string &key) const;
 
     /*******************************************************************
      * Register API
@@ -1147,11 +1167,29 @@ public:
     virtual void writeSetting(const std::string &key, const std::string &value);
 
     /*!
+     * Write a setting with an arbitrary value type.
+     * \tparam Type the data type of the value
+     * \param key the setting identifier
+     * \param value the setting value
+     */
+    template <typename Type>
+    void writeSetting(const std::string &key, const Type &value);
+
+    /*!
      * Read an arbitrary setting on the device.
      * \param key the setting identifier
      * \return the setting value
      */
     virtual std::string readSetting(const std::string &key) const;
+
+    /*!
+     * Read an arbitrary setting on the device.
+     * \tparam Type the return type for the sensor value
+     * \param key the setting identifier
+     * \return the setting value
+     */
+    template <typename Type>
+    Type readSetting(const std::string &key);
 
     /*!
      * Describe the allowed keys and values used for channel settings.
@@ -1172,6 +1210,17 @@ public:
     virtual void writeSetting(const int direction, const size_t channel, const std::string &key, const std::string &value);
 
     /*!
+     * Write an arbitrary channel setting on the device.
+     * \tparam Type the data type of the value
+     * \param direction the channel direction RX or TX
+     * \param channel an available channel on the device
+     * \param key the setting identifier
+     * \param value the setting value
+     */
+    template <typename Type>
+    void writeSetting(const int direction, const size_t channel, const std::string &key, const Type &value);
+
+    /*!
      * Read an arbitrary channel setting on the device.
      * \param direction the channel direction RX or TX
      * \param channel an available channel on the device
@@ -1179,6 +1228,17 @@ public:
      * \return the setting value
      */
     virtual std::string readSetting(const int direction, const size_t channel, const std::string &key) const;
+
+    /*!
+     * Read an arbitrary channel setting on the device.
+     * \tparam Type the return type for the sensor value
+     * \param direction the channel direction RX or TX
+     * \param channel an available channel on the device
+     * \param key the setting identifier
+     * \return the setting value
+     */
+    template <typename Type>
+    Type readSetting(const int direction, const size_t channel, const std::string &key);
 
     /*******************************************************************
      * GPIO API
@@ -1311,3 +1371,39 @@ public:
 };
 
 };
+
+template <typename Type>
+Type SoapySDR::Device::readSensor(const std::string &key) const
+{
+    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSensor(key));
+}
+
+template <typename Type>
+Type SoapySDR::Device::readSensor(const int direction, const size_t channel, const std::string &key) const
+{
+    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSensor(direction, channel, key));
+}
+
+template <typename Type>
+void SoapySDR::Device::writeSetting(const std::string &key, const Type &value)
+{
+    SoapySDR::Device::writeSetting(key, SoapySDR::SettingToString(value));
+}
+
+template <typename Type>
+Type SoapySDR::Device::readSetting(const std::string &key)
+{
+    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSetting(key));
+}
+
+template <typename Type>
+void SoapySDR::Device::writeSetting(const int direction, const size_t channel, const std::string &key, const Type &value)
+{
+    SoapySDR::Device::writeSetting(direction, channel, key, SoapySDR::SettingToString(value));
+}
+
+template <typename Type>
+Type SoapySDR::Device::readSetting(const int direction, const size_t channel, const std::string &key)
+{
+    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSetting(direction, channel, key));
+}

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -4,7 +4,7 @@
 /// Interface definition for Soapy SDR devices.
 ///
 /// \copyright
-/// Copyright (c) 2014-2018 Josh Blum
+/// Copyright (c) 2014-2019 Josh Blum
 /// Copyright (c) 2016-2016 Bastille Networks
 /// SPDX-License-Identifier: BSL-1.0
 ///
@@ -1375,35 +1375,35 @@ public:
 template <typename Type>
 Type SoapySDR::Device::readSensor(const std::string &key) const
 {
-    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSensor(key));
+    return SoapySDR::StringToSetting<Type>(this->readSensor(key));
 }
 
 template <typename Type>
 Type SoapySDR::Device::readSensor(const int direction, const size_t channel, const std::string &key) const
 {
-    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSensor(direction, channel, key));
+    return SoapySDR::StringToSetting<Type>(this->readSensor(direction, channel, key));
 }
 
 template <typename Type>
 void SoapySDR::Device::writeSetting(const std::string &key, const Type &value)
 {
-    SoapySDR::Device::writeSetting(key, SoapySDR::SettingToString(value));
+    this->writeSetting(key, SoapySDR::SettingToString(value));
 }
 
 template <typename Type>
 Type SoapySDR::Device::readSetting(const std::string &key)
 {
-    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSetting(key));
+    return SoapySDR::StringToSetting<Type>(this->readSetting(key));
 }
 
 template <typename Type>
 void SoapySDR::Device::writeSetting(const int direction, const size_t channel, const std::string &key, const Type &value)
 {
-    SoapySDR::Device::writeSetting(direction, channel, key, SoapySDR::SettingToString(value));
+    this->writeSetting(direction, channel, key, SoapySDR::SettingToString(value));
 }
 
 template <typename Type>
 Type SoapySDR::Device::readSetting(const int direction, const size_t channel, const std::string &key)
 {
-    return SoapySDR::StringToSetting<Type>(SoapySDR::Device::readSetting(direction, channel, key));
+    return SoapySDR::StringToSetting<Type>(this->readSetting(direction, channel, key));
 }

--- a/include/SoapySDR/Types.h
+++ b/include/SoapySDR/Types.h
@@ -16,6 +16,12 @@
 extern "C" {
 #endif
 
+//! String definition for boolean true used in settings
+#define SOAPY_SDR_TRUE "true"
+
+//! String definition for boolean false used in settings
+#define SOAPY_SDR_FALSE "false"
+
 //! Definition for a min/max numeric range
 typedef struct
 {

--- a/include/SoapySDR/Types.hpp
+++ b/include/SoapySDR/Types.hpp
@@ -186,13 +186,13 @@ typename std::enable_if<std::is_same<Type, bool>::value, Type>::type StringToSet
 }
 
 template <typename Type>
-typename std::enable_if<std::is_integral<Type>::value and std::is_signed<Type>::value, Type>::type StringToSetting(const std::string &s)
+typename std::enable_if<not std::is_same<Type, bool>::value and std::is_integral<Type>::value and std::is_signed<Type>::value, Type>::type StringToSetting(const std::string &s)
 {
     return Type(std::stoll(s));
 }
 
 template <typename Type>
-typename std::enable_if<std::is_integral<Type>::value and std::is_unsigned<Type>::value, Type>::type StringToSetting(const std::string &s)
+typename std::enable_if<not std::is_same<Type, bool>::value and std::is_integral<Type>::value and std::is_unsigned<Type>::value, Type>::type StringToSetting(const std::string &s)
 {
     return Type(std::stoull(s));
 }

--- a/include/SoapySDR/Types.hpp
+++ b/include/SoapySDR/Types.hpp
@@ -11,6 +11,7 @@
 #pragma once
 #include <SoapySDR/Config.hpp>
 #include <SoapySDR/Types.h>
+#include <type_traits>
 #include <vector>
 #include <string>
 #include <map>
@@ -35,6 +36,26 @@ SOAPY_SDR_API std::string KwargsToString(const Kwargs &args);
 
 //! Typedef for a list of key-word dictionaries
 typedef std::vector<Kwargs> KwargsList;
+
+/*!
+ * Convert a string to the specified type.
+ * Supports bools, integers, floats, and strings
+ * \tparam Type the specified output type
+ * \param s the setting value as a string
+ * \return the value converted to Type
+ */
+template <typename Type>
+Type StringToSetting(const std::string &s);
+
+/*!
+ * Convert an arbitrary type to a string.
+ * Supports bools, integers, floats, and strings
+ * \tparam Type the type of the input argument
+ * \param s the setting value as the specified type
+ * \return the value converted to a string
+ */
+template <typename Type>
+std::string SettingToString(const Type &s);
 
 /*!
  * A simple min/max numeric range pair
@@ -141,4 +162,84 @@ inline double SoapySDR::Range::maximum(void) const
 inline double SoapySDR::Range::step(void) const
 {
     return _step;
+}
+
+namespace SoapySDR {
+namespace Detail {
+
+
+//private implementation details for settings converters
+
+template <typename Type>
+typename std::enable_if<std::is_same<Type, bool>::value, Type>::type StringToSetting(const std::string &s)
+{
+    if (s == SOAPY_SDR_TRUE) return true;
+    if (s == SOAPY_SDR_FALSE) return false;
+
+    //zeros and empty strings are false
+    if (s == "0") return false;
+    if (s == "0.0") return false;
+    if (s == "") return false;
+
+    //other values are true
+    return "true";
+}
+
+template <typename Type>
+typename std::enable_if<std::is_integral<Type>::value and std::is_signed<Type>::value, Type>::type StringToSetting(const std::string &s)
+{
+    return Type(std::stoll(s));
+}
+
+template <typename Type>
+typename std::enable_if<std::is_integral<Type>::value and std::is_unsigned<Type>::value, Type>::type StringToSetting(const std::string &s)
+{
+    return Type(std::stoull(s));
+}
+
+template <typename Type>
+typename std::enable_if<std::is_floating_point<Type>::value, Type>::type StringToSetting(const std::string &s)
+{
+    return Type(std::stod(s));
+}
+
+template <typename Type>
+typename std::enable_if<std::is_same<typename std::decay<Type>::type, std::string>::value, Type>::type StringToSetting(const std::string &s)
+{
+    return s;
+}
+
+inline std::string SettingToString(const bool &s)
+{
+    return s?SOAPY_SDR_TRUE:SOAPY_SDR_FALSE;
+}
+
+inline std::string SettingToString(const char *s)
+{
+    return s;
+}
+
+inline std::string SettingToString(const std::string &s)
+{
+    return s;
+}
+
+template <typename Type>
+std::string SettingToString(const Type &s)
+{
+    return std::to_string(s);
+}
+
+}}
+
+template <typename Type>
+Type SoapySDR::StringToSetting(const std::string &s)
+{
+    return SoapySDR::Detail::StringToSetting<Type>(s);
+}
+
+template <typename Type>
+std::string SoapySDR::SettingToString(const Type &s)
+{
+    return SoapySDR::Detail::SettingToString(s);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,7 @@ add_test(TestFormatParser TestFormatParser)
 add_executable(TestKwargsMarkup TestKwargsMarkup.cpp)
 target_link_libraries(TestKwargsMarkup SoapySDR)
 add_test(TestKwargsMarkup TestKwargsMarkup)
+
+add_executable(TestConvertTypes TestConvertTypes.cpp)
+target_link_libraries(TestConvertTypes SoapySDR)
+add_test(TestConvertTypes TestConvertTypes)

--- a/tests/TestConvertTypes.cpp
+++ b/tests/TestConvertTypes.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2019-2019 Josh Blum
+// SPDX-License-Identifier: BSL-1.0
+
+#include <SoapySDR/Types.hpp>
+#include <cstdlib>
+#include <cstdio>
+#include <iostream>
+
+#define check_equal(x, y) \
+    printf("  Check %s == %s ... ", #x, #y); \
+    if ((x) != (y)) \
+    { \
+        printf("FAIL\n"); \
+        std::cout << "  -> " << x << " != " << y << std::endl; \
+        return EXIT_FAILURE; \
+    } \
+    else printf("PASS\n")
+
+int main(void)
+{
+    printf("Check boolean types:\n");
+    check_equal(SoapySDR::SettingToString(true), SOAPY_SDR_TRUE);
+    check_equal(SoapySDR::SettingToString(false), SOAPY_SDR_FALSE);
+    check_equal(SoapySDR::StringToSetting<bool>(SOAPY_SDR_TRUE), true);
+    check_equal(SoapySDR::StringToSetting<bool>(SOAPY_SDR_FALSE), false);
+
+    printf("Check integer types:\n");
+    check_equal(SoapySDR::SettingToString(0), "0");
+    check_equal(SoapySDR::SettingToString(-1), "-1");
+    check_equal(SoapySDR::SettingToString(1), "1");
+    check_equal(SoapySDR::SettingToString(100000000000000ull), "100000000000000");
+    check_equal(SoapySDR::SettingToString(-100000000000000ll), "-100000000000000");
+    check_equal(SoapySDR::StringToSetting<int>("0"), 0);
+    check_equal(SoapySDR::StringToSetting<int>("-1"), -1);
+    check_equal(SoapySDR::StringToSetting<int>("1"), 1);
+    check_equal(SoapySDR::StringToSetting<unsigned long long>("100000000000000"), 100000000000000ull);
+    check_equal(SoapySDR::StringToSetting<long long>("-100000000000000"), -100000000000000ll);
+
+    printf("Check string types:\n");
+    check_equal(SoapySDR::SettingToString(""), "");
+    check_equal(SoapySDR::SettingToString(std::string()), "");
+    check_equal(SoapySDR::SettingToString("hello"), "hello");
+    check_equal(SoapySDR::StringToSetting<std::string>(""), "");
+    check_equal(SoapySDR::StringToSetting<std::string>(std::string()), "");
+    check_equal(SoapySDR::StringToSetting<std::string>("hello"), "hello");
+
+    printf("Check float types:\n");
+    //floating point formatting is harder, cheat with std::to_string
+    check_equal(SoapySDR::SettingToString(0.0), std::to_string(0.0));
+    check_equal(SoapySDR::SettingToString(1.1), std::to_string(1.1));
+    check_equal(SoapySDR::SettingToString(-1.1), std::to_string(-1.1));
+    check_equal(SoapySDR::StringToSetting<double>("0.0"), 0.0);
+    check_equal(SoapySDR::StringToSetting<double>("1.1"), +1.1);
+    check_equal(SoapySDR::StringToSetting<double>("-1.1"), -1.1);
+
+    printf("DONE!\n");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Improvements to C++ and Python API for read/writeSettings and readSensor:

* added defines SOAPY_SDR_TRUE and SOAPY_SDR_FALSE for commonly used boolean settings
* added converters for driver implementations to use SettingToString, StringToSetting
* Device class overloads based on template type of setting/sensor

API use in c++
```
- d->writeSetting("FOO", std::to_string(1 << 13));
+ d->writeSetting("FOO", 1 << 13);

- auto v = std::stoi(d->readSetting("FOO"));
+ auto v = d->readSetting<int>("FOO");       #type cannot be inferred
```

API use in python
```
- d.writeSetting("FOO", str(1 << 13))
+ d.writeSetting("FOO", 1 << 13)

- v = int(d.readSetting("FOO"))
+ v = d.readSetting("FOO")       #type is inferred as int
```

Potential driver implementation changes:
```
SoapySDR::ArgInfoList SoapyHackRF::getSettingInfo(void) const
{
	SoapySDR::ArgInfoList setArgs;

	SoapySDR::ArgInfo biastxArg;
	biastxArg.key="bias_tx";
	- biastxArg.value="false";
	+ biastxArg.value=SOAPY_SDR_FALSE;
	biastxArg.name="Antenna Bias";
	biastxArg.description="Antenna port power control.";
	biastxArg.type=SoapySDR::ArgInfo::BOOL;
	setArgs.push_back(biastxArg);

	return setArgs;
}

void SoapyHackRF::writeSetting(const std::string &key, const std::string &value)
{
	if(key=="bias_tx"){
		std::lock_guard<std::mutex> lock(_device_mutex);
		- _tx_stream.bias=(value=="true") ? true : false;
		+ _tx_stream.bias=SoapySDR::StringToSetting<bool>(value);
		int ret=hackrf_set_antenna_enable(_dev,_tx_stream.bias);
		if(ret!=HACKRF_SUCCESS){
			SoapySDR_logf(SOAPY_SDR_INFO,"Failed to apply antenna bias voltage");
		}
	}
}

std::string SoapyHackRF::readSetting(const std::string &key) const
{
	if (key == "bias_tx") {
		- return _tx_stream.bias?"true":"false";
		+ return SoapySDR::SettingToString(_tx_stream.bias);
	}
	return "";
}
```