### PR TITLE
Add sensor readings and watch command

### DIFF
--- a/apps/SoapyRateTest.cpp
+++ b/apps/SoapyRateTest.cpp
@@ -13,7 +13,7 @@
 #include <cstdio>
 
 static sig_atomic_t loopDone = false;
-void sigIntHandler(const int)
+static void sigIntHandler(const int)
 {
     loopDone = true;
 }

--- a/apps/SoapySDRProbe.cpp
+++ b/apps/SoapySDRProbe.cpp
@@ -4,6 +4,7 @@
 
 #include <SoapySDR/Device.hpp>
 #include <sstream>
+#include <limits>
 
 template <typename Type>
 std::string toString(const std::vector<Type> &options)

--- a/apps/SoapySDRProbe.cpp
+++ b/apps/SoapySDRProbe.cpp
@@ -116,6 +116,64 @@ std::string toString(const SoapySDR::ArgInfoList &argInfos)
     return ss.str();
 }
 
+std::string sensorReadings(SoapySDR::Device *device)
+{
+    std::stringstream ss;
+
+    /*******************************************************************
+     * Sensor readings
+     ******************************************************************/
+    std::vector<std::string> sensors = device->listSensors();
+
+    for (size_t i = 0; i < sensors.size(); i++)
+    {
+        std::string key = sensors[i];
+        SoapySDR::ArgInfo info = device->getSensorInfo(key);
+        std::string reading = device->readSensor(key);
+
+        ss << "     * " << sensors[i];
+        if (not info.name.empty()) ss << " (" << info.name << ")";
+        ss << ":";
+        if (info.range.maximum() > std::numeric_limits<double>::min()) ss << toString(info.range);
+        ss << toString(info.options);
+        ss << " " << reading;
+        if (not info.units.empty()) ss << " " << info.units;
+        ss << std::endl;
+        if (not info.description.empty()) ss << "        " << info.description << std::endl;
+    }
+
+    return ss.str();
+}
+
+std::string channelSensorReadings(SoapySDR::Device *device, const int dir, const size_t chan)
+{
+    std::stringstream ss;
+
+    /*******************************************************************
+     * Channel sensor readings
+     ******************************************************************/
+    std::vector<std::string> sensors = device->listSensors(dir, chan);
+
+    for (size_t i = 0; i < sensors.size(); i++)
+    {
+        std::string key = sensors[i];
+        SoapySDR::ArgInfo info = device->getSensorInfo(dir, chan, key);
+        std::string reading = device->readSensor(dir, chan, key);
+
+        ss << "     * " << sensors[i];
+        if (not info.name.empty()) ss << " (" << info.name << ")";
+        ss << ":";
+        if (info.range.maximum() > std::numeric_limits<double>::min()) ss << toString(info.range);
+        ss << toString(info.options);
+        ss << " " << reading;
+        if (not info.units.empty()) ss << " " << info.units;
+        ss << std::endl;
+        if (not info.description.empty()) ss << "        " << info.description << std::endl;
+    }
+
+    return ss.str();
+}
+
 static std::string probeChannel(SoapySDR::Device *device, const int dir, const size_t chan)
 {
     std::stringstream ss;
@@ -197,6 +255,7 @@ static std::string probeChannel(SoapySDR::Device *device, const int dir, const s
     //sensors
     std::string sensors = toString(device->listSensors(dir, chan));
     if (not sensors.empty()) ss << "  Sensors: " << sensors << std::endl;
+    ss << channelSensorReadings(device, dir, chan);
 
     //settings
     std::string settings = toString(device->getSettingInfo(dir, chan));
@@ -246,6 +305,7 @@ std::string SoapySDRDeviceProbe(SoapySDR::Device *device)
 
     std::string sensors = toString(device->listSensors());
     if (not sensors.empty()) ss << "  Sensors: " << sensors << std::endl;
+    ss << sensorReadings(device);
 
     std::string registers = toString(device->listRegisterInterfaces());
     if (not registers.empty()) ss << "  Registers: " << registers << std::endl;

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 
 std::string SoapySDRDeviceProbe(SoapySDR::Device *);
+std::string sensorReadings(SoapySDR::Device *);
 int SoapySDRRateTest(
     const std::string &argStr,
     const double sampleRate,
@@ -45,6 +46,7 @@ static int printHelp(void)
     std::cout << "    --find[=\"driver=foo,type=bar\"] \t Discover available devices" << std::endl;
     std::cout << "    --make[=\"driver=foo,type=bar\"] \t Create a device instance" << std::endl;
     std::cout << "    --probe[=\"driver=foo,type=bar\"] \t Print detailed information" << std::endl;
+    std::cout << "    --watch[=\"driver=foo,type=bar\"] \t Watch device sensor information" << std::endl;
     std::cout << std::endl;
 
     std::cout << "  Advanced options:" << std::endl;
@@ -211,6 +213,31 @@ static int probeDevice(const std::string &argStr)
 }
 
 /***********************************************************************
+ * Make device and watch sensor info
+ **********************************************************************/
+static int watchDevice(const std::string &argStr)
+{
+    std::cout << "Watch device " << argStr << std::endl;
+    try
+    {
+        auto device = SoapySDR::Device::make(argStr);
+        for (;;)
+        {
+            std::cout << sensorReadings(device) << std::endl;
+            sleep(1);
+        }
+        SoapySDR::Device::unmake(device);
+    }
+    catch (const std::exception &ex)
+    {
+        std::cerr << "Error watching device: " << ex.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::cout << std::endl;
+    return EXIT_SUCCESS;
+}
+
+/***********************************************************************
  * Check the registry for a specific driver
  **********************************************************************/
 static int checkDriver(const std::string &driverName)
@@ -248,6 +275,7 @@ int main(int argc, char *argv[])
     bool sparsePrintFlag(false);
     bool makeDeviceFlag(false);
     bool probeDeviceFlag(false);
+    bool watchDeviceFlag(false);
 
     /*******************************************************************
      * parse command line options
@@ -258,6 +286,7 @@ int main(int argc, char *argv[])
         {"make", optional_argument, 0, 'm'},
         {"info", optional_argument, 0, 'i'},
         {"probe", optional_argument, 0, 'p'},
+        {"watch", optional_argument, 0, 'w'},
 
         {"check", optional_argument, 0, 'c'},
         {"sparse", no_argument, 0, 's'},
@@ -292,6 +321,10 @@ int main(int argc, char *argv[])
             probeDeviceFlag = true;
             if (optarg != nullptr) argStr = optarg;
             break;
+        case 'w':
+            watchDeviceFlag = true;
+            if (optarg != nullptr) argStr = optarg;
+            break;
         case 'c':
             if (optarg != nullptr) driverName = optarg;
             break;
@@ -318,6 +351,7 @@ int main(int argc, char *argv[])
     if (findDevicesFlag) return findDevices(argStr, sparsePrintFlag);
     if (makeDeviceFlag)  return makeDevice(argStr);
     if (probeDeviceFlag) return probeDevice(argStr);
+    if (watchDeviceFlag) return watchDevice(argStr);
 
     //invoke utilities that rely on multiple arguments
     if (sampleRate != 0.0)

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -6,6 +6,8 @@
 #include <SoapySDR/Registry.hpp>
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/ConverterRegistry.hpp>
+#include <chrono>
+#include <thread>
 #include <algorithm> //sort, min, max
 #include <cstdlib>
 #include <cstddef>
@@ -224,7 +226,7 @@ static int watchDevice(const std::string &argStr)
         for (;;)
         {
             std::cout << sensorReadings(device) << std::endl;
-            sleep(1);
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         }
         SoapySDR::Device::unmake(device);
     }


### PR DESCRIPTION
This adds sensor readings and a watch command to SoapySDRUtil.
E.g. `SoapySDRUtil --probe="driver=plutosdr"` will follow "Peripheral summary" / "Sensors:" with a table of current sensors readings.
Also e.g. the new `SoapySDRUtil --watch="driver=plutosdr"` will output a table of sensors readings every second.