### PR TITLE
try/except for site.getsitepackages()

### DIFF
--- a/python/get_python_lib.py
+++ b/python/get_python_lib.py
@@ -6,12 +6,14 @@ from distutils.sysconfig import get_python_lib
 if __name__ == '__main__':
     prefix = sys.argv[1]
 
-    #use sites when the prefix is already recognized
-    paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
-    if len(paths) == 1: install_dir = paths[0]
-
     #ask distutils where to install the python module
-    else: install_dir = get_python_lib(plat_specific=True, prefix=prefix)
+    install_dir = get_python_lib(plat_specific=True, prefix=prefix)
+
+    #use sites when the prefix is already recognized
+    try:
+        paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
+        if len(paths) == 1: install_dir = paths[0]
+    except AttributeError: pass
 
     #strip the prefix to return a relative path
     print(os.path.relpath(install_dir, prefix))


### PR DESCRIPTION
In the never ending python install path whack-a-mole, site.getsitepackages() sometimes does not exist

* resolves https://github.com/pothosware/SoapySDR/issues/239

* @gasparka are you able to test this change on your setup?