### PR TITLE
adding reference clock to the clocking API

### DIFF
--- a/include/SoapySDR/Device.h
+++ b/include/SoapySDR/Device.h
@@ -1088,10 +1088,80 @@ SOAPY_SDR_API double SoapySDRDevice_getMasterClockRate(const SoapySDRDevice *dev
 SOAPY_SDR_API SoapySDRRange *SoapySDRDevice_getMasterClockRates(const SoapySDRDevice *device, size_t *length);
 
 /*!
+ * Get the list of available master clock sources.
+ * \param device a pointer to a device instance
+ * \param [out] length the number of sources
+ * \return a list of clock source names
+ */
+SOAPY_SDR_API char **SoapySDRDevice_listMasterClockSources(const SoapySDRDevice *device, size_t *length);
+
+/*!
+ * Set the master clock source on the device
+ * \param device a pointer to a device instance
+ * \param source the name of a clock source
+ * \return an error code or 0 for success
+ */
+SOAPY_SDR_API int SoapySDRDevice_setMasterClockSource(SoapySDRDevice *device, const char *source);
+
+/*!
+ * Get the master clock source of the device
+ * \param device a pointer to a device instance
+ * \return the name of a clock source
+ */
+SOAPY_SDR_API char *SoapySDRDevice_getMasterClockSource(const SoapySDRDevice *device);
+
+/*!
+ * Set the reference clock rate of the device.
+ * \param device a pointer to a device instance
+ * \param rate the clock rate in Hz
+ * \return an error code or 0 for success
+ */
+SOAPY_SDR_API int SoapySDRDevice_setReferenceClockRate(SoapySDRDevice *device, const double rate);
+
+/*!
+ * Get the reference clock rate of the device.
+ * \param device a pointer to a device instance
+ * \return the clock rate in Hz
+ */
+SOAPY_SDR_API double SoapySDRDevice_getReferenceClockRate(const SoapySDRDevice *device);
+
+/*!
+ * Get the range of available reference clock rates.
+ * \param device a pointer to a device instance
+ * \param [out] length the number of sources
+ * \return a list of clock rate ranges in Hz
+ */
+SOAPY_SDR_API SoapySDRRange *SoapySDRDevice_getReferenceClockRates(const SoapySDRDevice *device, size_t *length);
+
+/*!
+ * Get the list of available reference clock sources.
+ * \param device a pointer to a device instance
+ * \param [out] length the number of sources
+ * \return a list of clock source names
+ */
+SOAPY_SDR_API char **SoapySDRDevice_listReferenceClockSources(const SoapySDRDevice *device, size_t *length);
+
+/*!
+ * Set the reference clock source on the device
+ * \param device a pointer to a device instance
+ * \param source the name of a clock source
+ * \return an error code or 0 for success
+ */
+SOAPY_SDR_API int SoapySDRDevice_setReferenceClockSource(SoapySDRDevice *device, const char *source);
+
+/*!
+ * Get the reference clock source of the device
+ * \param device a pointer to a device instance
+ * \return the name of a clock source
+ */
+SOAPY_SDR_API char *SoapySDRDevice_getReferenceClockSource(const SoapySDRDevice *device);
+
+/*!
  * Get the list of available clock sources.
  * \param device a pointer to a device instance
  * \param [out] length the number of sources
  * \return a list of clock source names
+ * \deprecated see listMasterClockSources and listReferenceClockSources
  */
 SOAPY_SDR_API char **SoapySDRDevice_listClockSources(const SoapySDRDevice *device, size_t *length);
 
@@ -1100,6 +1170,7 @@ SOAPY_SDR_API char **SoapySDRDevice_listClockSources(const SoapySDRDevice *devic
  * \param device a pointer to a device instance
  * \param source the name of a clock source
  * \return an error code or 0 for success
+ * \deprecated see setMasterClockSource and setReferenceClockSource
  */
 SOAPY_SDR_API int SoapySDRDevice_setClockSource(SoapySDRDevice *device, const char *source);
 
@@ -1107,6 +1178,7 @@ SOAPY_SDR_API int SoapySDRDevice_setClockSource(SoapySDRDevice *device, const ch
  * Get the clock source of the device
  * \param device a pointer to a device instance
  * \return the name of a clock source
+ * \deprecated see getMasterClockSource and getReferenceClockSource
  */
 SOAPY_SDR_API char *SoapySDRDevice_getClockSource(const SoapySDRDevice *device);
 

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -957,20 +957,77 @@ public:
     virtual RangeList getMasterClockRates(void) const;
 
     /*!
+     * Get the list of available master clock sources.
+     * \return a list of clock source names
+     */
+    virtual std::vector<std::string> listMasterClockSources(void) const;
+
+    /*!
+     * Set the master clock source on the device
+     * \param source the name of a clock source
+     */
+    virtual void setMasterClockSource(const std::string &source);
+
+    /*!
+     * Get the master clock source of the device
+     * \return the name of a clock source
+     */
+    virtual std::string getMasterClockSource(void) const;
+
+    /*!
+     * Set the reference clock rate of the device.
+     * \param rate the clock rate in Hz
+     */
+    virtual void setReferenceClockRate(const double rate);
+
+    /*!
+     * Get the reference clock rate of the device.
+     * \return the clock rate in Hz
+     */
+    virtual double getReferenceClockRate(void) const;
+
+    /*!
+     * Get the range of available reference clock rates.
+     * \return a list of clock rate ranges in Hz
+     */
+    virtual RangeList getReferenceClockRates(void) const;
+
+    /*!
+     * Get the list of available reference clock sources.
+     * \return a list of clock source names
+     */
+    virtual std::vector<std::string> listReferenceClockSources(void) const;
+
+    /*!
+     * Set the reference clock source on the device
+     * \param source the name of a clock source
+     */
+    virtual void setReferenceClockSource(const std::string &source);
+
+    /*!
+     * Get the reference clock source of the device
+     * \return the name of a clock source
+     */
+    virtual std::string getReferenceClockSource(void) const;
+
+    /*!
      * Get the list of available clock sources.
      * \return a list of clock source names
+     * \deprecated see listMasterClockSources and listReferenceClockSources
      */
     virtual std::vector<std::string> listClockSources(void) const;
 
     /*!
      * Set the clock source on the device
      * \param source the name of a clock source
+     * \deprecated see setMasterClockSource and setReferenceClockSource
      */
     virtual void setClockSource(const std::string &source);
 
     /*!
      * Get the clock source of the device
      * \return the name of a clock source
+     * \deprecated see getMasterClockSource and getReferenceClockSource
      */
     virtual std::string getClockSource(void) const;
 

--- a/lib/Device.cpp
+++ b/lib/Device.cpp
@@ -586,6 +586,51 @@ SoapySDR::RangeList SoapySDR::Device::getMasterClockRates(void) const
     return SoapySDR::RangeList();
 }
 
+std::vector<std::string> SoapySDR::Device::listMasterClockSources(void) const
+{
+    return std::vector<std::string>();
+}
+
+void SoapySDR::Device::setMasterClockSource(const std::string &source)
+{
+    return;
+}
+
+std::string SoapySDR::Device::getMasterClockSource(void) const
+{
+    return "";
+}
+
+void SoapySDR::Device::setReferenceClockRate(const double rate)
+{
+    return;
+}
+
+double SoapySDR::Device::getReferenceClockRate(void) const
+{
+    return 0.0;
+}
+
+SoapySDR::RangeList SoapySDR::Device::getReferenceClockRates(void) const
+{
+    return SoapySDR::RangeList();
+}
+
+std::vector<std::string> SoapySDR::Device::listReferenceClockSources(void) const
+{
+    return std::vector<std::string>();
+}
+
+void SoapySDR::Device::setReferenceClockSource(const std::string &source)
+{
+    return;
+}
+
+std::string SoapySDR::Device::getReferenceClockSource(void) const
+{
+    return "";
+}
+
 std::vector<std::string> SoapySDR::Device::listClockSources(void) const
 {
     return std::vector<std::string>();

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -647,6 +647,72 @@ SoapySDRRange *SoapySDRDevice_getMasterClockRates(const SoapySDRDevice *device, 
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
+char **SoapySDRDevice_listMasterClockSources(const SoapySDRDevice *device, size_t *length)
+{
+    *length = 0;
+    __SOAPY_SDR_C_TRY
+    return toStrArray(device->listMasterClockSources(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
+int SoapySDRDevice_setMasterClockSource(SoapySDRDevice *device, const char *source)
+{
+    __SOAPY_SDR_C_TRY
+    device->setMasterClockSource(source);
+    __SOAPY_SDR_C_CATCH
+}
+
+char *SoapySDRDevice_getMasterClockSource(const SoapySDRDevice *device)
+{
+    __SOAPY_SDR_C_TRY
+    return toCString(device->getMasterClockSource());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
+int SoapySDRDevice_setReferenceClockRate(SoapySDRDevice *device, const double rate)
+{
+    __SOAPY_SDR_C_TRY
+    device->setReferenceClockRate(rate);
+    __SOAPY_SDR_C_CATCH
+}
+
+double SoapySDRDevice_getReferenceClockRate(const SoapySDRDevice *device)
+{
+    __SOAPY_SDR_C_TRY
+    return device->getReferenceClockRate();
+    __SOAPY_SDR_C_CATCH_RET(NAN);
+}
+
+SoapySDRRange *SoapySDRDevice_getReferenceClockRates(const SoapySDRDevice *device, size_t *length)
+{
+    *length = 0;
+    __SOAPY_SDR_C_TRY
+    return toRangeList(device->getReferenceClockRates(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
+char **SoapySDRDevice_listReferenceClockSources(const SoapySDRDevice *device, size_t *length)
+{
+    *length = 0;
+    __SOAPY_SDR_C_TRY
+    return toStrArray(device->listReferenceClockSources(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
+int SoapySDRDevice_setReferenceClockSource(SoapySDRDevice *device, const char *source)
+{
+    __SOAPY_SDR_C_TRY
+    device->setReferenceClockSource(source);
+    __SOAPY_SDR_C_CATCH
+}
+
+char *SoapySDRDevice_getReferenceClockSource(const SoapySDRDevice *device)
+{
+    __SOAPY_SDR_C_TRY
+    return toCString(device->getReferenceClockSource());
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
 char **SoapySDRDevice_listClockSources(const SoapySDRDevice *device, size_t *length)
 {
     *length = 0;


### PR DESCRIPTION
Updated the clocking API to separate the concepts of master clock and reference clock. See #276 