### PR TITLE
adding reference clock to the clocking API

### DIFF
--- a/include/SoapySDR/Device.h
+++ b/include/SoapySDR/Device.h
@@ -1088,6 +1088,29 @@ SOAPY_SDR_API double SoapySDRDevice_getMasterClockRate(const SoapySDRDevice *dev
 SOAPY_SDR_API SoapySDRRange *SoapySDRDevice_getMasterClockRates(const SoapySDRDevice *device, size_t *length);
 
 /*!
+ * Set the reference clock rate of the device.
+ * \param device a pointer to a device instance
+ * \param rate the clock rate in Hz
+ * \return an error code or 0 for success
+ */
+SOAPY_SDR_API int SoapySDRDevice_setReferenceClockRate(SoapySDRDevice *device, const double rate);
+
+/*!
+ * Get the reference clock rate of the device.
+ * \param device a pointer to a device instance
+ * \return the clock rate in Hz
+ */
+SOAPY_SDR_API double SoapySDRDevice_getReferenceClockRate(const SoapySDRDevice *device);
+
+/*!
+ * Get the range of available reference clock rates.
+ * \param device a pointer to a device instance
+ * \param [out] length the number of sources
+ * \return a list of clock rate ranges in Hz
+ */
+SOAPY_SDR_API SoapySDRRange *SoapySDRDevice_getReferenceClockRates(const SoapySDRDevice *device, size_t *length);
+
+/*!
  * Get the list of available clock sources.
  * \param device a pointer to a device instance
  * \param [out] length the number of sources

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -957,6 +957,24 @@ public:
     virtual RangeList getMasterClockRates(void) const;
 
     /*!
+     * Set the reference clock rate of the device.
+     * \param rate the clock rate in Hz
+     */
+    virtual void setReferenceClockRate(const double rate);
+
+    /*!
+     * Get the reference clock rate of the device.
+     * \return the clock rate in Hz
+     */
+    virtual double getReferenceClockRate(void) const;
+
+    /*!
+     * Get the range of available reference clock rates.
+     * \return a list of clock rate ranges in Hz
+     */
+    virtual RangeList getReferenceClockRates(void) const;
+
+    /*!
      * Get the list of available clock sources.
      * \return a list of clock source names
      */

--- a/lib/Device.cpp
+++ b/lib/Device.cpp
@@ -586,6 +586,21 @@ SoapySDR::RangeList SoapySDR::Device::getMasterClockRates(void) const
     return SoapySDR::RangeList();
 }
 
+void SoapySDR::Device::setReferenceClockRate(const double rate)
+{
+    return;
+}
+
+double SoapySDR::Device::getReferenceClockRate(void) const
+{
+    return 0.0;
+}
+
+SoapySDR::RangeList SoapySDR::Device::getReferenceClockRates(void) const
+{
+    return SoapySDR::RangeList();
+}
+
 std::vector<std::string> SoapySDR::Device::listClockSources(void) const
 {
     return std::vector<std::string>();

--- a/lib/DeviceC.cpp
+++ b/lib/DeviceC.cpp
@@ -647,6 +647,28 @@ SoapySDRRange *SoapySDRDevice_getMasterClockRates(const SoapySDRDevice *device, 
     __SOAPY_SDR_C_CATCH_RET(nullptr);
 }
 
+int SoapySDRDevice_setReferenceClockRate(SoapySDRDevice *device, const double rate)
+{
+    __SOAPY_SDR_C_TRY
+    device->setReferenceClockRate(rate);
+    __SOAPY_SDR_C_CATCH
+}
+
+double SoapySDRDevice_getReferenceClockRate(const SoapySDRDevice *device)
+{
+    __SOAPY_SDR_C_TRY
+    return device->getReferenceClockRate();
+    __SOAPY_SDR_C_CATCH_RET(NAN);
+}
+
+SoapySDRRange *SoapySDRDevice_getReferenceClockRates(const SoapySDRDevice *device, size_t *length)
+{
+    *length = 0;
+    __SOAPY_SDR_C_TRY
+    return toRangeList(device->getReferenceClockRates(), length);
+    __SOAPY_SDR_C_CATCH_RET(nullptr);
+}
+
 char **SoapySDRDevice_listClockSources(const SoapySDRDevice *device, size_t *length)
 {
     *length = 0;


### PR DESCRIPTION
As requested in #277
> I would like to include the ref clock API for setReferenceClockRate/getReferenceClockRate/getReferenceClockRates. Can I get the PR for just that change?