### PR TITLE
Unload modules

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -14,6 +14,7 @@ API:
 - Added Templated StringToSetting() and SettingToString() helpers
 - Python bindings duck typing for read/writeSetting()/readSensor()
 - Changed SoapySDRDevice_setupStream() to return the stream pointer
+- Added unloadModules() API call to manually cleanup modules on exit
 
 Release 0.7.2 (2020-01-12)
 ==========================

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Version.hpp>
@@ -278,6 +278,15 @@ static int checkDriver(const std::string &driverName)
  **********************************************************************/
 int main(int argc, char *argv[])
 {
+    //unload any loaded modules when main() scope unwinds
+    struct UnloadModulesScopeExit
+    {
+        ~UnloadModulesScopeExit(void)
+        {
+            SoapySDR::unloadModules();
+        }
+    } unloadModulesInstance;
+
     std::string serial;
     std::string argStr;
     std::string chanStr;

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -279,13 +279,7 @@ static int checkDriver(const std::string &driverName)
 int main(int argc, char *argv[])
 {
     //unload any loaded modules when main() scope unwinds
-    struct UnloadModulesScopeExit
-    {
-        ~UnloadModulesScopeExit(void)
-        {
-            SoapySDR::unloadModules();
-        }
-    } unloadModulesInstance;
+    SoapySDR::ModuleManager mm(false);
 
     std::string serial;
     std::string argStr;

--- a/include/SoapySDR/Modules.h
+++ b/include/SoapySDR/Modules.h
@@ -6,7 +6,7 @@
 /// For most use cases, the API will automatically load modules.
 ///
 /// \copyright
-/// Copyright (c) 2014-2018 Josh Blum
+/// Copyright (c) 2014-2020 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -86,6 +86,11 @@ SOAPY_SDR_API char *SoapySDR_unloadModule(const char *path);
  * Subsequent calls are a NOP.
  */
 SOAPY_SDR_API void SoapySDR_loadModules(void);
+
+/*!
+ * Unload all currently loaded support modules.
+ */
+SOAPY_SDR_API void SoapySDR_unloadModules(void);
 
 #ifdef __cplusplus
 }

--- a/include/SoapySDR/Modules.hpp
+++ b/include/SoapySDR/Modules.hpp
@@ -6,7 +6,7 @@
 /// For most use cases, the API will automatically load modules.
 ///
 /// \copyright
-/// Copyright (c) 2014-2018 Josh Blum
+/// Copyright (c) 2014-2020 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -79,6 +79,11 @@ SOAPY_SDR_API std::string unloadModule(const std::string &path);
  * Subsequent calls are a NOP.
  */
 SOAPY_SDR_API void loadModules(void);
+
+/*!
+ * Unload all currently loaded support modules.
+ */
+SOAPY_SDR_API void unloadModules(void);
 
 //! \cond
 //! Internal call to register version with a module during load

--- a/include/SoapySDR/Modules.hpp
+++ b/include/SoapySDR/Modules.hpp
@@ -85,6 +85,27 @@ SOAPY_SDR_API void loadModules(void);
  */
 SOAPY_SDR_API void unloadModules(void);
 
+/*!
+ * Manage the lifetime of loadable modules
+ * by unloading modules on scope exit.
+ */
+class SOAPY_SDR_API ModuleManager
+{
+public:
+    /*!
+     * Create an instance of the module manager.
+     * Loading modules on creation can be disabled.
+     * \param load false to skip loading modules
+     */
+    ModuleManager(const bool load = true);
+
+    /*!
+     * Module manager destructor.
+     * Unload modules on cleanup.
+     */
+    ~ModuleManager(void);
+};
+
 //! \cond
 //! Internal call to register version with a module during load
 class SOAPY_SDR_API ModuleVersion

--- a/include/SoapySDR/Version.h
+++ b/include/SoapySDR/Version.h
@@ -4,7 +4,7 @@
 /// Utility functions to query version information.
 ///
 /// \copyright
-/// Copyright (c) 2014-2020 Josh Blum
+/// Copyright (c) 2014-2021 Josh Blum
 /// Copyright (c) 2016-2016 Bastille Networks
 /// SPDX-License-Identifier: BSL-1.0
 ///
@@ -151,6 +151,11 @@
  * Compatibility define for ref clock rate API
  */
 #define SOAPY_SDR_API_HAS_REF_CLOCK_RATE_API
+
+/*!
+ * Compatibility define for unloading modules
+ */
+#define SOAPY_SDR_API_HAS_UNLOAD_MODULES_API
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/Modules.in.cpp
+++ b/lib/Modules.in.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 Josh Blum
+// Copyright (c) 2014-2020 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Modules.hpp>
@@ -351,5 +351,18 @@ void SoapySDR::loadModules(void)
             if (it.second.empty()) continue;
             SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::loadModule(%s)\n  %s", paths[i].c_str(), it.second.c_str());
         }
+    }
+}
+
+void SoapySDR::unloadModules(void)
+{
+    std::lock_guard<std::recursive_mutex> lock(getModuleMutex());
+    for (auto it = getModuleHandles().begin(); it != getModuleHandles().end();)
+    {
+        auto path = it->first; //save path
+        it++; //advance iterator
+        auto msg = unloadModule(path);
+        if (msg.empty()) continue;
+        SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::unloadModule(%s)\n  %s", path.c_str(), msg.c_str());
     }
 }

--- a/lib/Modules.in.cpp
+++ b/lib/Modules.in.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Modules.hpp>
@@ -365,4 +365,14 @@ void SoapySDR::unloadModules(void)
         if (msg.empty()) continue;
         SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::unloadModule(%s)\n  %s", path.c_str(), msg.c_str());
     }
+}
+
+SoapySDR::ModuleManager::ModuleManager(const bool load)
+{
+    if (load) SoapySDR::loadModules();
+}
+
+SoapySDR::ModuleManager::~ModuleManager(void)
+{
+    SoapySDR::unloadModules();
 }

--- a/lib/ModulesC.cpp
+++ b/lib/ModulesC.cpp
@@ -70,4 +70,9 @@ void SoapySDR_loadModules(void)
     SoapySDR::loadModules();
 }
 
+void SoapySDR_unloadModules(void)
+{
+    SoapySDR::unloadModules();
+}
+
 }


### PR DESCRIPTION
Added unload modules API to unload all modules and cleanup internal data structures.

Should be called manually on application exit.

* closes https://github.com/pothosware/SoapySDR/issues/280