### PR TITLE
Add new CMake policies to build if present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,20 @@ project(SoapySDR)
 enable_language(CXX)
 enable_testing()
 
+# Enable newer CMake policies if available
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW) # option() honors normal variables
+endif()
+if(POLICY CMP0078)
+    cmake_policy(SET CMP0078 NEW) # UseSWIG generates standard target names
+endif()
+if(POLICY CMP0086)
+    cmake_policy(SET CMP0086 NEW) # UseSWIG honors SWIG_MODULE_NAME via -module flag
+endif()
+if(POLICY CMP0068)
+    cmake_policy(SET CMP0068 NEW) # RPATH settings on macOS do not affect install_name
+endif()
+
 #C++11 is a required language feature for this project
 set(CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
Needed as with newer CMake versions, SWIG is very noisy at build time due to these new policies not being enabled. Example output with policies not enabled:

```
CMake Warning (dev) at /Applications/CLion.app/Contents/bin/cmake/mac/share/cmake-3.19/Modules/UseSWIG.cmake:661 (message):
  Policy CMP0078 is not set: UseSWIG generates standard target names.  Run
  "cmake --help-policy CMP0078" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

Call Stack (most recent call first):
  ExternalLibs/SoapySDR/python/CMakeLists.txt:160 (SWIG_ADD_LIBRARY)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /Applications/CLion.app/Contents/bin/cmake/mac/share/cmake-3.19/Modules/UseSWIG.cmake:513 (message):
  Policy CMP0086 is not set: UseSWIG honors SWIG_MODULE_NAME via -module
  flag.  Run "cmake --help-policy CMP0086" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /Applications/CLion.app/Contents/bin/cmake/mac/share/cmake-3.19/Modules/UseSWIG.cmake:764 (SWIG_ADD_SOURCE_TO_MODULE)
  ExternalLibs/SoapySDR/python/CMakeLists.txt:160 (SWIG_ADD_LIBRARY)
```