### PR TITLE
Fix misc. typos

### DIFF
--- a/buildkite/build.sh
+++ b/buildkite/build.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-echo "--- Enviroment."
+echo "--- Environment."
 env
 
 #

--- a/include/SoapySDR/Device.h
+++ b/include/SoapySDR/Device.h
@@ -142,7 +142,7 @@ SOAPY_SDR_API int SoapySDRDevice_unmake_list(SoapySDRDevice **devices, const siz
 /*!
  * A key that uniquely identifies the device driver.
  * This key identifies the underlying implementation.
- * Serveral variants of a product may share a driver.
+ * Several variants of a product may share a driver.
  * \param device a pointer to a device instance
  */
 SOAPY_SDR_API char *SoapySDRDevice_getDriverKey(const SoapySDRDevice *device);

--- a/include/SoapySDR/Device.hpp
+++ b/include/SoapySDR/Device.hpp
@@ -27,7 +27,7 @@ namespace SoapySDR
 class Stream;
 
 /*!
- * Abstraction for an SDR tranceiver device - configuration and streaming.
+ * Abstraction for an SDR transceiver device - configuration and streaming.
  */
 class SOAPY_SDR_API Device
 {
@@ -120,7 +120,7 @@ public:
     /*!
      * A key that uniquely identifies the device driver.
      * This key identifies the underlying implementation.
-     * Serveral variants of a product may share a driver.
+     * Several variants of a product may share a driver.
      */
     virtual std::string getDriverKey(void) const;
 


### PR DESCRIPTION
Found via `codespell -q 3 -L devicec,dne,inout,ue`