### PR TITLE
Types: When converting strings to bool, be as unsurprising as possible

### DIFF
--- a/include/SoapySDR/Types.hpp
+++ b/include/SoapySDR/Types.hpp
@@ -13,6 +13,7 @@
 #include <SoapySDR/Types.h>
 #include <type_traits>
 #include <vector>
+#include <stdexcept>
 #include <string>
 #include <map>
 
@@ -173,16 +174,19 @@ namespace Detail {
 template <typename Type>
 typename std::enable_if<std::is_same<Type, bool>::value, Type>::type StringToSetting(const std::string &s)
 {
-    if (s == SOAPY_SDR_TRUE) return true;
-    if (s == SOAPY_SDR_FALSE) return false;
-
-    //zeros and empty strings are false
-    if (s == "0") return false;
-    if (s == "0.0") return false;
-    if (s == "") return false;
-
-    //other values are true
+  if (s.empty() or s == SOAPY_SDR_FALSE) {
+    return false;
+  }
+  if (s == SOAPY_SDR_TRUE) {
     return true;
+  }
+  try {
+    // C++: Float conversion to bool is unambiguous
+    return std::stod(s);
+  } catch (std::invalid_argument&) {
+  }
+  // other values are true
+  return true;
 }
 
 template <typename Type>

--- a/tests/TestConvertTypes.cpp
+++ b/tests/TestConvertTypes.cpp
@@ -23,6 +23,19 @@ int main(void)
     check_equal(SoapySDR::SettingToString(false), SOAPY_SDR_FALSE);
     check_equal(SoapySDR::StringToSetting<bool>(SOAPY_SDR_TRUE), true);
     check_equal(SoapySDR::StringToSetting<bool>(SOAPY_SDR_FALSE), false);
+    check_equal(SoapySDR::StringToSetting<bool>("one-headed donkey"), true);
+    check_equal(SoapySDR::StringToSetting<bool>("+"), true);
+    check_equal(SoapySDR::StringToSetting<bool>(""), false);
+    check_equal(SoapySDR::StringToSetting<bool>("0"), false);
+    check_equal(SoapySDR::StringToSetting<bool>("0.2"), true);
+    check_equal(SoapySDR::StringToSetting<bool>("1"), true);
+    check_equal(SoapySDR::StringToSetting<bool>("-42"), true);
+    check_equal(SoapySDR::StringToSetting<bool>("0.0"), false);
+    check_equal(SoapySDR::StringToSetting<bool>("1.0"), true);
+    check_equal(SoapySDR::StringToSetting<bool>("0e12"), false);
+    check_equal(SoapySDR::StringToSetting<bool>("0.2e12"), true);
+    check_equal(SoapySDR::StringToSetting<bool>("000"), false);
+    check_equal(SoapySDR::StringToSetting<bool>("001"), true);
 
     printf("Check integer types:\n");
     check_equal(SoapySDR::SettingToString(0), "0");


### PR DESCRIPTION
Used to special case "0" and "0.0", ignoring the many other (beautiful
in their own right) ways to specify 0 numerals.

No reason to be be that tricky and implement stuff ourselves – C++11 has
safe converters that everyone is familiar with.

