### PR TITLE
python3 - change OUTPUT_NAME in newer versions of cmake

### DIFF
--- a/python3/CMakeLists.txt
+++ b/python3/CMakeLists.txt
@@ -82,7 +82,13 @@ endif()
 target_include_directories(${SWIG_MODULE_SoapySDR3_REAL_NAME} PRIVATE ${PYTHON3_INCLUDE_DIRS})
 SWIG_LINK_LIBRARIES(SoapySDR3 SoapySDR ${PYTHON3_LIBRARIES})
 
-set_target_properties(${SWIG_MODULE_SoapySDR3_REAL_NAME} PROPERTIES OUTPUT_NAME _SoapySDR)
+#Changed in version 3.15: Alternate library name (set with the OUTPUT_NAME property, for example)
+#will be passed on to Python and CSharp wrapper libraries.
+if(${CMAKE_VERSION} VERSION_LESS "3.15")
+    set_target_properties(${SWIG_MODULE_SoapySDR3_REAL_NAME} PROPERTIES OUTPUT_NAME _SoapySDR)
+else()
+    set_target_properties(${SWIG_MODULE_SoapySDR3_REAL_NAME} PROPERTIES OUTPUT_NAME SoapySDR)
+endif()
 
 ########################################################################
 # Install Module


### PR DESCRIPTION
From UseSWIG:

Changed in version 3.15: Alternate library name (set with the OUTPUT_NAME property, for example)
will be passed on to Python and CSharp wrapper libraries

The issue:

This seems to cause an extra underscrore in the output name which breaks
the imports and .i file. The fix is to set the name conditionally

Notes:

This should not affect users building python modules from the default
python/ directory. Its only the special python3/ extra directory.