### PR TITLE
windows: robustify the windows ifdefs

### DIFF
--- a/lib/LoggerC.cpp
+++ b/lib/LoggerC.cpp
@@ -37,9 +37,9 @@ static SoapySDRLogLevel getDefaultLogLevel(void)
 }
 
 /***********************************************************************
- * Compatibility for vasprintf under MSVC
+ * Compatibility for vasprintf on Windows
  **********************************************************************/
-#ifdef _MSC_VER
+#ifdef _WIN32
 int vasprintf(char **strp, const char *fmt, va_list ap)
 {
     int r = _vscprintf(fmt, ap);

--- a/lib/LoggerC.cpp
+++ b/lib/LoggerC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <SoapySDR/Logger.h>
@@ -35,20 +35,6 @@ static SoapySDRLogLevel getDefaultLogLevel(void)
     if (logLevelInt > SOAPY_SDR_TRACE) return SOAPY_SDR_TRACE;
     return SoapySDRLogLevel(logLevelInt);
 }
-
-/***********************************************************************
- * Compatibility for vasprintf on Windows
- **********************************************************************/
-#ifdef _WIN32
-int vasprintf(char **strp, const char *fmt, va_list ap)
-{
-    int r = _vscprintf(fmt, ap);
-    if (r < 0) return r;
-    *strp = (char *)malloc(r+1);
-    if (*strp == nullptr) return -1;
-    return vsprintf_s(*strp, r+1, fmt, ap);
-}
-#endif
 
 /***********************************************************************
  * ANSI terminal colors for default logger
@@ -95,11 +81,10 @@ void SoapySDR_log(const SoapySDRLogLevel logLevel, const char *message)
 void SoapySDR_vlogf(const SoapySDRLogLevel logLevel, const char *format, va_list argList)
 {
     if (logLevel > registeredLogLevel) return;
-    char *message = NULL;
-    if (vasprintf(&message, format, argList) != -1)
+    char message[8*1024];
+    if (std::vsnprintf(message, sizeof(message), format, argList) > 0)
     {
         SoapySDR_log(logLevel, message);
-        free(message);
     }
 }
 

--- a/lib/Modules.in.cpp
+++ b/lib/Modules.in.cpp
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <map>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <dlfcn.h>
@@ -29,7 +29,7 @@ static std::recursive_mutex &getModuleMutex(void)
  **********************************************************************/
 std::string getEnvImpl(const char *name)
 {
-    #ifdef _MSC_VER
+    #ifdef _WIN32
     const DWORD len = GetEnvironmentVariableA(name, 0, 0);
     if (len == 0) return "";
     char* buffer = new char[len];
@@ -52,7 +52,7 @@ std::string SoapySDR::getRootPath(void)
     // Get the path to the current dynamic linked library.
     // The path to this library can be used to determine
     // the installation root without prior knowledge.
-    #ifdef _MSC_VER
+    #ifdef _WIN32
     char path[MAX_PATH];
     HMODULE hm = NULL;
     if (GetModuleHandleExA(
@@ -83,7 +83,7 @@ static std::vector<std::string> searchModulePath(const std::string &path)
     std::vector<std::string> modulePaths;
     const std::string pattern = path + "*@MODULE_EXT@";
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     //http://stackoverflow.com/questions/612097/how-can-i-get-a-list-of-files-in-a-directory-using-c-or-c
     WIN32_FIND_DATA fd; 
     HANDLE hFind = ::FindFirstFile(pattern.c_str(), &fd); 
@@ -136,7 +136,7 @@ std::vector<std::string> SoapySDR::listSearchPaths(void)
     }
 
     //separator for search paths
-    #ifdef _MSC_VER
+    #ifdef _WIN32
     static const char sep = ';';
     #else
     static const char sep = ':';
@@ -207,7 +207,7 @@ SoapySDR::ModuleVersion::ModuleVersion(const std::string &version)
     getModuleVersions()[getModuleLoading()] = version;
 }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 static std::string GetLastErrorMessage(void)
 {
     LPVOID lpMsgBuf;
@@ -245,7 +245,7 @@ std::string SoapySDR::loadModule(const std::string &path)
     getModuleLoading().assign(path);
 
     //load the module
-#ifdef _MSC_VER
+#ifdef _WIN32
 
     //SetThreadErrorMode() - disable error pop-ups when DLLs are not found
     DWORD oldMode;
@@ -292,7 +292,7 @@ std::string SoapySDR::unloadModule(const std::string &path)
 
     //unload the module
     void *handle = getModuleHandles()[path];
-#ifdef _MSC_VER
+#ifdef _WIN32
     BOOL success = FreeLibrary((HMODULE)handle);
     getModuleLoading().clear();
     if (not success) return "FreeLibrary() failed: " + GetLastErrorMessage();


### PR DESCRIPTION
rather than rely on msvc macros, use cmake checks for windows header and missing API calls

* closes https://github.com/pothosware/SoapySDR/pull/318