### PR TITLE
fix module search paths, if CMAKE_INSTALL_LIB_DIR is absolute

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -111,6 +111,10 @@ endif()
 ########################################################################
 # Configure sources
 ########################################################################
+
+#get a relative CMAKE_INSTALL_LIBDIR for the the module loader logic
+file(RELATIVE_PATH CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}" "${CMAKE_INSTALL_FULL_LIBDIR}")
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/Modules.in.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/Modules.cpp


### PR DESCRIPTION
CMake allows for `CMAKE_INSTALL_LIB_DIR` to be absolute: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

Some linux distributions (at least NixOS) set this path as absolute by default, which causes problems with module-loading, as the constructed search path, concatenated from `SoapySDR::getRootPath()` and `CMAKE_INSTALL_LIB_DIR`, contains the common path-prefix twice.

I would thus suggest to use `CMAKE_INSTALL_LIB_DIR` unchanged, if it is absolute (starts with `/`).

This should have no impact on Windows targeted builds - but that's just a guess, as I'm not using Windows.
A better solution would probably be to use [std::filesystem::operator/](https://en.cppreference.com/w/cpp/filesystem/path/operator_slash). But this is only available from C++17 onwards.