### PR TITLE
Fix Wnon-virtual-dtor to conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 project(SoapySDR)
 enable_language(CXX)
 enable_testing()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -80,7 +80,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
     #common warnings to help encourage good coding practices
     target_compile_options(SoapySDR PUBLIC -Wall)
     target_compile_options(SoapySDR PUBLIC -Wextra)
-    target_compile_options(SoapySDR PUBLIC -Wnon-virtual-dtor)
+    target_compile_options(SoapySDR PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
 endif()
 
 if (MSVC)


### PR DESCRIPTION
The `target_compile_options` on `SoapySDR PUBLIC` (i.e. `INTERFACE_COMPILE_OPTIONS` via `SoapySDRExport.cmake` in dependent projects) needs `-Wnon-virtual-dtor` conditional for only C++ compilers, otherwise C-projects will get
```
error: command-line option ‘-Wnon-virtual-dtor’ is valid for C++/ObjC++ but not for C
```
