### PR TITLE
pkg-config: Use cmake full paths instead of manually concatenating

### DIFF
--- a/lib/SoapySDR.in.pc
+++ b/lib/SoapySDR.in.pc
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Soapy SDR
 Description: Vendor and platform neutral SDR interface library.


### PR DESCRIPTION
See #352 for details around the bug