### PR TITLE
Fix toArgInfo() options count with empty optionNames in C binding

### DIFF
--- a/lib/TypeHelpers.hpp
+++ b/lib/TypeHelpers.hpp
@@ -136,8 +136,9 @@ static inline SoapySDRArgInfo toArgInfo(const SoapySDR::ArgInfo &info)
         out.units = toCString(info.units);
         out.type = SoapySDRArgInfoType(info.type);
         out.range = toRange(info.range);
-        out.options = toStrArray(info.options, &out.numOptions);
         out.optionNames = toStrArray(info.optionNames, &out.numOptions);
+        // do options after optionNames so correct numOptions is reported if no optionNames
+        out.options = toStrArray(info.options, &out.numOptions);
     }
     catch (const std::bad_alloc &)
     {


### PR DESCRIPTION
report options count rather than optionNames count to C binding
fixes https://github.com/pothosware/SoapySDR/issues/377 