### PR TITLE
Add `.gitignore` to exclude `build/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore CMake generated output
+build/


### PR DESCRIPTION
Because the default build instructions recommend an in-tree build output directory, this change adds the directory name to `.gitignore` so that the git tree is not marked as dirty after running the build instructions.