### PR TITLE
Treat MSYS CMake installation paths as Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ find_package(SoapySDR CONFIG REQUIRED)
 # Install cmake helper modules
 ########################################################################
 include(CMakePackageConfigHelpers)
-if (UNIX)
+if (UNIX OR MSYS)
     set(CMAKE_LIB_DEST ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
 elseif (WIN32)
     set(CMAKE_LIB_DEST cmake)


### PR DESCRIPTION
I am currently contribugint to MSYS by adding SoapySDR as a package. In the process, I found that CMake treats MSYS as WIN32 and changes CMake files installation paths...

This proposes a fix to avoid having to patch source for MSYS distribution.

More info on https://github.com/msys2/MINGW-packages/pull/17446.
