### PR TITLE
Treat MinGW CMake installation paths as Unix instead of MSYS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ find_package(SoapySDR CONFIG REQUIRED)
 # Install cmake helper modules
 ########################################################################
 include(CMakePackageConfigHelpers)
-if (UNIX OR MINGW)
+if (UNIX OR MSYS OR MINGW)
     set(CMAKE_LIB_DEST ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
 elseif (WIN32)
     set(CMAKE_LIB_DEST cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ find_package(SoapySDR CONFIG REQUIRED)
 # Install cmake helper modules
 ########################################################################
 include(CMakePackageConfigHelpers)
-if (UNIX OR MSYS)
+if (UNIX OR MINGW)
     set(CMAKE_LIB_DEST ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
 elseif (WIN32)
     set(CMAKE_LIB_DEST cmake)


### PR DESCRIPTION
Based on @Biswa96 review on https://github.com/pothosware/SoapySDR/pull/413, a better fix is proposed.

Sorry about the double PR! :)