### PR TITLE
TypeHelpers: pre-callocate optionNames even if no names are provided

### DIFF
--- a/include/SoapySDR/Types.h
+++ b/include/SoapySDR/Types.h
@@ -91,7 +91,7 @@ typedef struct
      */
     SoapySDRRange range;
 
-    //! The size of the options set, or 0 when not used.
+    //! The size of the options and optionNames sets, or 0 when not used.
     size_t numOptions;
 
     /*!
@@ -102,7 +102,8 @@ typedef struct
 
     /*!
      * A discrete list of displayable names for the enumerated options (optional)
-     * When not specified, the option value itself can be used as a display name.
+     * When not specified, the respective entry in this list will be NULL, and
+     * the option key itself can be used as a display name instead.
      */
     char **optionNames;
 

--- a/lib/TypeHelpers.hpp
+++ b/lib/TypeHelpers.hpp
@@ -31,9 +31,9 @@ static inline char *toCString(const std::string &s)
     return out;
 }
 
-static inline char **toStrArray(const std::vector<std::string> &strs, size_t *length)
+static inline char **toStrArray(const std::vector<std::string> &strs, size_t *length, size_t minLength = 0)
 {
-    auto out = callocArrayType<char *>(strs.size());
+    auto out = callocArrayType<char *>(std::max(minLength, strs.size()));
     for (size_t i = 0; i < strs.size(); i++)
     {
         try
@@ -136,9 +136,10 @@ static inline SoapySDRArgInfo toArgInfo(const SoapySDR::ArgInfo &info)
         out.units = toCString(info.units);
         out.type = SoapySDRArgInfoType(info.type);
         out.range = toRange(info.range);
-        out.optionNames = toStrArray(info.optionNames, &out.numOptions);
-        // do options after optionNames so correct numOptions is reported if no optionNames
         out.options = toStrArray(info.options, &out.numOptions);
+        size_t namesLength = 0;
+        // will be calloc-ed to be at least as long as options to prevent clients from reading garbage
+        out.optionNames = toStrArray(info.optionNames, &namesLength, out.numOptions);
     }
     catch (const std::bad_alloc &)
     {


### PR DESCRIPTION
The SoapySDRArgInfo struct has an optional `optionNames` array. However, the client has no way of knowing whether these labels were filled by the SDR driver or are left uninitialized. Allocating and zeroing the array is more foolproof, in my opinion, and does not break the ABI.

See: https://github.com/pothosware/SoapySDR/issues/377#issuecomment-2480732739