### PR TITLE
Update cmake_policy in swig for CMake 3.12 compat

### DIFF
--- a/swig/python/cmake/FindPython/Support.cmake
+++ b/swig/python/cmake/FindPython/Support.cmake
@@ -7,7 +7,7 @@
 
 cmake_policy (GET CMP0094 _${_PYTHON_PREFIX}_LOOKUP_POLICY)
 
-cmake_policy (VERSION 3.7)
+cmake_policy (VERSION 3.7...3.14)
 
 if (_${_PYTHON_PREFIX}_LOOKUP_POLICY)
   cmake_policy (SET CMP0094 ${_${_PYTHON_PREFIX}_LOOKUP_POLICY})


### PR DESCRIPTION
Update `cmake_policy` to new `3.12` format for `3.14` compat which is already used by policies in main CMakeLists.txt.

We could possibly use `3.15` as `max` and remove the [`CMP0094`](https://cmake.org/cmake/help/latest/policy/CMP0094.html) setting but I have not tested that.

This reduces the warnings when building with swig to just the LuaJIT warning.

S.a. #450