### PR TITLE
Update GitHub Actions for MacOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,21 +135,24 @@ jobs:
             matrix:
                 build_type: [Release, Debug]
                 config:
-                    - cc: gcc-11
-                      cxx: g++-11
-                      test_luajit: false
-                      os: macos-11
-                      python3_ver: '3.8'
+                    - cc: gcc-14
+                      cxx: g++-14
+                      os: macos-14
+                      python3_ver: '3.9'
 
                     - cc: clang
                       cxx: clang++
-                      test_luajit: true
-                      os: macos-11
-                      python3_ver: '3.8'
+                      os: macos-14
+                      python3_ver: '3.9'
 
                     - cc: clang
                       cxx: clang++
-                      os: macos-12
+                      os: macos-13
+                      python3_ver: '3.9'
+
+                    - cc: clang
+                      cxx: clang++
+                      os: macos-15
                       python3_ver: '3.9'
         runs-on: ${{matrix.config.os}}
         env:
@@ -160,10 +163,7 @@ jobs:
           - uses: actions/checkout@v2
           - name: Install dependencies
             run: |
-                brew install doxygen luajit
-                which luajit
-                pip install numpy
-                pip3 install numpy
+                brew install --formula doxygen luajit numpy swig
 
                 # Installing Lua 5.1 dependencies via package is ugly
                 cd ${{runner.workspace}}
@@ -179,9 +179,11 @@ jobs:
           - name: Install
             run: |
                 cd ${{github.workspace}}/build
+                install_name_tool -add_rpath @executable_path/../lib apps/SoapySDRUtil
                 sudo make install
           - name: Run unit tests
             run: |
+                export DYLD_LIBRARY_PATH=/usr/local/lib
                 cd ${{github.workspace}}/build
                 ctest --output-on-failure
           - name: Test SoapySDRUtil
@@ -203,8 +205,8 @@ jobs:
                 python${{matrix.config.python3_ver}} -c "import SoapySDR; print(SoapySDR.errToStr(SoapySDR.SOAPY_SDR_TIMEOUT))"
                 python${{matrix.config.python3_ver}} -c "import SoapySDR; print(SoapySDR.Device.make('driver=null'))"
           - name: Test LuaJIT bindings
-            if: ${{ matrix.config.test_luajit }}
             run: |
+                export DYLD_LIBRARY_PATH=/usr/local/lib
                 luajit -e 'SoapySDR = require("SoapySDR"); print(SoapySDR.API_VERSION)'
                 luajit -e 'SoapySDR = require("SoapySDR"); print(SoapySDR.ABI_VERSION)'
                 luajit -e 'SoapySDR = require("SoapySDR"); print(SoapySDR.Error.TIMEOUT)'


### PR DESCRIPTION
MacOS 11 and 12 runners are not supported anymore. Switches to 13, 14, and 15 runners.

Also removes the `test_luajit` conditional as the test works on all runners now.