### PR TITLE
soapysdr: g++ 15.1.0 causes warning about deprecation of ciso646

### DIFF
--- a/include/SoapySDR/Config.hpp
+++ b/include/SoapySDR/Config.hpp
@@ -10,4 +10,3 @@
 
 #pragma once
 #include <SoapySDR/Config.h>
-#include <ciso646>


### PR DESCRIPTION
 - #warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
 - SoapySDR can build without this file.  It appears it was used to allow for and, or and not instead of &&, ||, !.
 - tested if this was needed in soapysdr, soapyrtlsdr and soapyhackrf and they all build properly without the header.