### PR TITLE
Replace alternative operator representations

### DIFF
--- a/apps/SoapyRateTest.cpp
+++ b/apps/SoapyRateTest.cpp
@@ -44,7 +44,7 @@ void runRateTestStreamLoop(
     std::cout << "Starting stream loop, press Ctrl+C to exit..." << std::endl;
     device->activateStream(stream);
     signal(SIGINT, sigIntHandler);
-    while (not loopDone)
+    while (!loopDone)
     {
         int ret(0);
         int flags(0);
@@ -129,8 +129,8 @@ int SoapySDRRateTest(
 
         //parse the direction to the integer enum
         int direction(-1);
-        if (directionStr == "RX" or directionStr == "rx") direction = SOAPY_SDR_RX;
-        if (directionStr == "TX" or directionStr == "tx") direction = SOAPY_SDR_TX;
+        if (directionStr == "RX" || directionStr == "rx") direction = SOAPY_SDR_RX;
+        if (directionStr == "TX" || directionStr == "tx") direction = SOAPY_SDR_TX;
         if (direction == -1) throw std::invalid_argument("direction not in RX/TX: " + directionStr);
 
         //build channels list, using KwargsFromString is a easy parsing hack

--- a/apps/SoapySDRProbe.cpp
+++ b/apps/SoapySDRProbe.cpp
@@ -13,7 +13,7 @@ std::string toString(const std::vector<Type> &options)
     if (options.empty()) return "";
     for (size_t i = 0; i < options.size(); i++)
     {
-        if (not ss.str().empty()) ss << ", ";
+        if (!ss.str().empty()) ss << ", ";
         ss << options[i];
     }
     return ss.str();
@@ -34,12 +34,12 @@ std::string toString(const SoapySDR::RangeList &range, const double scale)
     std::stringstream ss;
     for (size_t i = 0; i < range.size(); i++)
     {
-        if (range.size() >= MAXRLEN and i >= MAXRLEN/2 and i < (range.size()-MAXRLEN/2))
+        if (range.size() >= MAXRLEN && i >= MAXRLEN/2 && i < (range.size()-MAXRLEN/2))
         {
             if (i == MAXRLEN) ss << ", ...";
             continue;
         }
-        if (not ss.str().empty()) ss << ", ";
+        if (!ss.str().empty()) ss << ", ";
         if (range[i].minimum() == range[i].maximum()) ss << (range[i].minimum()/scale);
         else ss << "[" << (range[i].minimum()/scale) << ", " << (range[i].maximum()/scale) << "]";
     }
@@ -58,7 +58,7 @@ std::string toString(const std::vector<double> &nums, const double scale)
 
     for (size_t i = 0; i < nums.size(); i++)
     {
-        if (not ss.str().empty()) ss << ", ";
+        if (!ss.str().empty()) ss << ", ";
         ss << (nums[i]/scale);
     }
     return "[" + ss.str() + "]";
@@ -80,12 +80,12 @@ std::string toString(const SoapySDR::ArgInfo &argInfo, const std::string indent 
     {
         desc.replace(pos, 1, replace);
     }
-    if (not desc.empty()) ss << " - " << desc << std::endl << indent << "  ";
+    if (!desc.empty()) ss << " - " << desc << std::endl << indent << "  ";
 
     //other fields
     ss << " [key=" << argInfo.key;
-    if (not argInfo.units.empty()) ss << ", units=" << argInfo.units;
-    if (not argInfo.value.empty()) ss << ", default=" << argInfo.value;
+    if (!argInfo.units.empty()) ss << ", units=" << argInfo.units;
+    if (!argInfo.value.empty()) ss << ", default=" << argInfo.value;
 
     //type
     switch (argInfo.type)
@@ -98,7 +98,7 @@ std::string toString(const SoapySDR::ArgInfo &argInfo, const std::string indent 
 
     //optional range/enumeration
     if (argInfo.range.minimum() < argInfo.range.maximum()) ss << ", range=" << toString(argInfo.range);
-    if (not argInfo.options.empty()) ss << ", options=(" << toString(argInfo.options) << ")";
+    if (!argInfo.options.empty()) ss << ", options=(" << toString(argInfo.options) << ")";
 
     ss << "]";
 
@@ -133,14 +133,14 @@ std::string sensorReadings(SoapySDR::Device *device)
         std::string reading = device->readSensor(key);
 
         ss << "     * " << sensors[i];
-        if (not info.name.empty()) ss << " (" << info.name << ")";
+        if (!info.name.empty()) ss << " (" << info.name << ")";
         ss << ":";
         if (info.range.maximum() > std::numeric_limits<double>::min()) ss << toString(info.range);
         ss << toString(info.options);
         ss << " " << reading;
-        if (not info.units.empty()) ss << " " << info.units;
+        if (!info.units.empty()) ss << " " << info.units;
         ss << std::endl;
-        if (not info.description.empty()) ss << "        " << info.description << std::endl;
+        if (!info.description.empty()) ss << "        " << info.description << std::endl;
     }
 
     return ss.str();
@@ -162,14 +162,14 @@ std::string channelSensorReadings(SoapySDR::Device *device, const int dir, const
         std::string reading = device->readSensor(dir, chan, key);
 
         ss << "     * " << sensors[i];
-        if (not info.name.empty()) ss << " (" << info.name << ")";
+        if (!info.name.empty()) ss << " (" << info.name << ")";
         ss << ":";
         if (info.range.maximum() > std::numeric_limits<double>::min()) ss << toString(info.range);
         ss << toString(info.options);
         ss << " " << reading;
-        if (not info.units.empty()) ss << " " << info.units;
+        if (!info.units.empty()) ss << " " << info.units;
         ss << std::endl;
-        if (not info.description.empty()) ss << "        " << info.description << std::endl;
+        if (!info.description.empty()) ss << "        " << info.description << std::endl;
     }
 
     return ss.str();
@@ -201,7 +201,7 @@ static std::string probeChannel(SoapySDR::Device *device, const int dir, const s
 
     //formats
     std::string formats = toString(device->getStreamFormats(dir, chan));
-    if (not formats.empty()) ss << "  Stream formats: " << formats << std::endl;
+    if (!formats.empty()) ss << "  Stream formats: " << formats << std::endl;
 
     //native
     double fullScale = 0.0;
@@ -210,11 +210,11 @@ static std::string probeChannel(SoapySDR::Device *device, const int dir, const s
 
     //stream args
     std::string streamArgs = toString(device->getStreamArgsInfo(dir, chan));
-    if (not streamArgs.empty()) ss << "  Stream args:" << std::endl << streamArgs;
+    if (!streamArgs.empty()) ss << "  Stream args:" << std::endl << streamArgs;
 
     //antennas
     std::string antennas = toString(device->listAntennas(dir, chan));
-    if (not antennas.empty()) ss << "  Antennas: " << antennas << std::endl;
+    if (!antennas.empty()) ss << "  Antennas: " << antennas << std::endl;
 
     //corrections
     std::vector<std::string> correctionsList;
@@ -222,7 +222,7 @@ static std::string probeChannel(SoapySDR::Device *device, const int dir, const s
     if (device->hasDCOffset(dir, chan)) correctionsList.push_back("DC offset");
     if (device->hasIQBalance(dir, chan)) correctionsList.push_back("IQ balance");
     std::string corrections = toString(correctionsList);
-    if (not corrections.empty()) ss << "  Corrections: " << corrections << std::endl;
+    if (!corrections.empty()) ss << "  Corrections: " << corrections << std::endl;
 
     //gains
     ss << "  Full gain range: " << toString(device->getGainRange(dir, chan)) << " dB" << std::endl;
@@ -244,23 +244,23 @@ static std::string probeChannel(SoapySDR::Device *device, const int dir, const s
 
     //freq args
     std::string freqArgs = toString(device->getFrequencyArgsInfo(dir, chan));
-    if (not freqArgs.empty()) ss << "  Tune args:" << std::endl << freqArgs;
+    if (!freqArgs.empty()) ss << "  Tune args:" << std::endl << freqArgs;
 
     //rates
     ss << "  Sample rates: " << toString(device->getSampleRateRange(dir, chan), 1e6) << " MSps" << std::endl;
 
     //bandwidths
     const auto bws = device->getBandwidthRange(dir, chan);
-    if (not bws.empty()) ss << "  Filter bandwidths: " << toString(bws, 1e6) << " MHz" << std::endl;
+    if (!bws.empty()) ss << "  Filter bandwidths: " << toString(bws, 1e6) << " MHz" << std::endl;
 
     //sensors
     std::string sensors = toString(device->listSensors(dir, chan));
-    if (not sensors.empty()) ss << "  Sensors: " << sensors << std::endl;
+    if (!sensors.empty()) ss << "  Sensors: " << sensors << std::endl;
     ss << channelSensorReadings(device, dir, chan);
 
     //settings
     std::string settings = toString(device->getSettingInfo(dir, chan));
-    if (not settings.empty()) ss << "  Other Settings:" << std::endl << settings;
+    if (!settings.empty()) ss << "  Other Settings:" << std::endl << settings;
 
     return ss.str();
 }
@@ -299,26 +299,26 @@ std::string SoapySDRDeviceProbe(SoapySDR::Device *device)
     ss << "  Timestamps: " << (device->hasHardwareTime()?"YES":"NO") << std::endl;
 
     std::string clockSources = toString(device->listClockSources());
-    if (not clockSources.empty()) ss << "  Clock sources: " << clockSources << std::endl;
+    if (!clockSources.empty()) ss << "  Clock sources: " << clockSources << std::endl;
 
     std::string timeSources = toString(device->listTimeSources());
-    if (not timeSources.empty()) ss << "  Time sources: " << timeSources << std::endl;
+    if (!timeSources.empty()) ss << "  Time sources: " << timeSources << std::endl;
 
     std::string sensors = toString(device->listSensors());
-    if (not sensors.empty()) ss << "  Sensors: " << sensors << std::endl;
+    if (!sensors.empty()) ss << "  Sensors: " << sensors << std::endl;
     ss << sensorReadings(device);
 
     std::string registers = toString(device->listRegisterInterfaces());
-    if (not registers.empty()) ss << "  Registers: " << registers << std::endl;
+    if (!registers.empty()) ss << "  Registers: " << registers << std::endl;
 
     std::string settings = toString(device->getSettingInfo());
-    if (not settings.empty()) ss << "  Other Settings:" << std::endl << settings;
+    if (!settings.empty()) ss << "  Other Settings:" << std::endl << settings;
 
     std::string gpios = toString(device->listGPIOBanks());
-    if (not gpios.empty()) ss << "  GPIOs: " << gpios << std::endl;
+    if (!gpios.empty()) ss << "  GPIOs: " << gpios << std::endl;
 
     std::string uarts = toString(device->listUARTs());
-    if (not uarts.empty()) ss << "  UARTs: " << uarts << std::endl;
+    if (!uarts.empty()) ss << "  UARTs: " << uarts << std::endl;
 
     /*******************************************************************
      * Per-channel info

--- a/apps/SoapySDRUtil.cpp
+++ b/apps/SoapySDRUtil.cpp
@@ -107,9 +107,9 @@ static int printInfo(void)
     {
         std::cout << "Module found: " << mod;
         const auto &errMsg = SoapySDR::loadModule(mod);
-        if (not errMsg.empty()) std::cout << "\n  " << errMsg;
+        if (!errMsg.empty()) std::cout << "\n  " << errMsg;
         const auto version = SoapySDR::getModuleVersion(mod);
-        if (not version.empty()) std::cout << std::string(maxPathLen-mod.size(), ' ') << " (" << version << ")";
+        if (!version.empty()) std::cout << std::string(maxPathLen-mod.size(), ' ') << " (" << version << ")";
         std::cout << std::endl;
     }
     if (modules.empty()) std::cout << "No modules found!" << std::endl;
@@ -118,7 +118,7 @@ static int printInfo(void)
     std::string factories;
     for (const auto &it : SoapySDR::Registry::listFindFunctions())
     {
-        if (not factories.empty()) factories += ", ";
+        if (!factories.empty()) factories += ", ";
         factories += it.first;
     }
     if (factories.empty()) factories = "No factories found!";
@@ -130,7 +130,7 @@ static int printInfo(void)
         std::string targets;
         for (const auto &target : SoapySDR::ConverterRegistry::listTargetFormats(source))
         {
-            if (not targets.empty()) targets += ", ";
+            if (!targets.empty()) targets += ", ";
             targets += target;
         }
         std::cout << " - " << std::setw(5) << source << " -> [" << targets << "]" << std::endl;
@@ -235,7 +235,7 @@ static int watchDevice(const std::string &argStr)
     try
     {
         auto device = SoapySDR::Device::make(argStr);
-        while (not loopDone)
+        while (!loopDone)
         {
             std::cout << sensorReadings(device) << std::endl;
             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -374,15 +374,15 @@ int main(int argc, char *argv[])
     }
 
     //use serial if provided
-    if (not serial.empty())
+    if (!serial.empty())
     {
         auto args = SoapySDR::KwargsFromString(argStr);
         args["serial"] = serial;
         argStr = SoapySDR::KwargsToString(args);
     }
 
-    if (not sparsePrintFlag) printBanner();
-    if (not driverName.empty()) return checkDriver(driverName);
+    if (!sparsePrintFlag) printBanner();
+    if (!driverName.empty()) return checkDriver(driverName);
     if (findDevicesFlag) return findDevices(argStr, sparsePrintFlag);
     if (makeDeviceFlag)  return makeDevice(argStr);
     if (probeDeviceFlag) return probeDevice(argStr);

--- a/include/SoapySDR/Config.hpp
+++ b/include/SoapySDR/Config.hpp
@@ -10,9 +10,3 @@
 
 #pragma once
 #include <SoapySDR/Config.h>
-
-#if (defined(_MSVC_LANG) || __cplusplus < 201703L)
-  // For old or nonconforming compilers,
-  // using the alternative operator representations may require including this header.
-  #include <ciso646>
-#endif

--- a/include/SoapySDR/Types.hpp
+++ b/include/SoapySDR/Types.hpp
@@ -176,7 +176,7 @@ namespace Detail {
 template <typename Type>
 typename std::enable_if<std::is_same<Type, bool>::value, Type>::type StringToSetting(const std::string &s)
 {
-  if (s.empty() or s == SOAPY_SDR_FALSE) {
+  if (s.empty() || s == SOAPY_SDR_FALSE) {
     return false;
   }
   if (s == SOAPY_SDR_TRUE) {
@@ -189,7 +189,7 @@ typename std::enable_if<std::is_same<Type, bool>::value, Type>::type StringToSet
 
     // Either the input wasn't numeric, so str_end should point to the front of the string,
     // or the whole string was consumed and the resulting number is non-zero.
-    return (s == str_end) or ((d != 0.0) and (std::strlen(str_end) == 0));
+    return (s == str_end) || ((d != 0.0) && (std::strlen(str_end) == 0));
   } catch (std::invalid_argument&) {
   }
   // other values are true
@@ -197,13 +197,13 @@ typename std::enable_if<std::is_same<Type, bool>::value, Type>::type StringToSet
 }
 
 template <typename Type>
-typename std::enable_if<not std::is_same<Type, bool>::value and std::is_integral<Type>::value and std::is_signed<Type>::value, Type>::type StringToSetting(const std::string &s)
+typename std::enable_if<!std::is_same<Type, bool>::value && std::is_integral<Type>::value && std::is_signed<Type>::value, Type>::type StringToSetting(const std::string &s)
 {
     return Type(std::stoll(s));
 }
 
 template <typename Type>
-typename std::enable_if<not std::is_same<Type, bool>::value and std::is_integral<Type>::value and std::is_unsigned<Type>::value, Type>::type StringToSetting(const std::string &s)
+typename std::enable_if<!std::is_same<Type, bool>::value && std::is_integral<Type>::value && std::is_unsigned<Type>::value, Type>::type StringToSetting(const std::string &s)
 {
     return Type(std::stoull(s));
 }

--- a/lib/Device.cpp
+++ b/lib/Device.cpp
@@ -58,8 +58,8 @@ bool SoapySDR::Device::getFullDuplex(const int, const size_t) const
 {
     auto numRxChs = this->getNumChannels(SOAPY_SDR_RX);
     auto numTxChs = this->getNumChannels(SOAPY_SDR_TX);
-    if (numRxChs > 0 and numTxChs == 0) return false; //no tx channels
-    if (numRxChs == 0 and numTxChs > 0) return false; //no rx channels
+    if (numRxChs > 0 && numTxChs == 0) return false; //no tx channels
+    if (numRxChs == 0 && numTxChs > 0) return false; //no rx channels
     return true; //assume full duplex (usually true minus some tdd devices)
 }
 
@@ -373,11 +373,11 @@ void SoapySDR::Device::setFrequency(const int dir, const size_t chan, double fre
         //add offset for RF element (first element)
         if (comp_i == 0) freq += offset;
 
-        if (args.count(name) != 0 and args.at(name) == "IGNORE")
+        if (args.count(name) != 0 && args.at(name) == "IGNORE")
         {
             //do nothing, dont change component
         }
-        else if (args.count(name) != 0 and args.at(name) != "DEFAULT")
+        else if (args.count(name) != 0 && args.at(name) != "DEFAULT")
         {
             //specific frequency for component specified
             const double f(std::atof(args.at(name).c_str()));
@@ -485,7 +485,7 @@ SoapySDR::ArgInfoList SoapySDR::Device::getFrequencyArgsInfo(const int dir, cons
         info.type = SoapySDR::ArgInfo::FLOAT;
         info.description = "Tune the LO with an offset and compensate with the baseband CORDIC.";
         SoapySDR::RangeList ranges = this->getFrequencyRange(dir, chan, comps.at(1));
-        if (not ranges.empty()) info.range = ranges.front();
+        if (!ranges.empty()) info.range = ranges.front();
         args.push_back(info);
     }
 
@@ -503,7 +503,7 @@ SoapySDR::ArgInfoList SoapySDR::Device::getFrequencyArgsInfo(const int dir, cons
         info.options.push_back("IGNORE");
         info.optionNames.push_back("Ignore");
         SoapySDR::RangeList ranges = this->getFrequencyRange(dir, chan, comps.at(comp_i));
-        if (not ranges.empty()) info.range = ranges.front();
+        if (!ranges.empty()) info.range = ranges.front();
         args.push_back(info);
     }
 

--- a/lib/Factory.cpp
+++ b/lib/Factory.cpp
@@ -69,14 +69,14 @@ SoapySDR::KwargsList SoapySDR::Device::enumerate(const Kwargs &args)
     for (const auto &it : Registry::listFindFunctions())
     {
         const bool specifiedDriver = args.count("driver") != 0;
-        if (specifiedDriver and args.at("driver") != it.first) continue;
+        if (specifiedDriver && args.at("driver") != it.first) continue;
 
         //protect the cache to search it for results and update it
         std::lock_guard<std::recursive_mutex> lock(cacheMutex);
         auto &cacheEntry = cache[std::make_pair(it.first, args)];
 
         //use the cache entry if its been initialized (valid) and not expired
-        if (cacheEntry.second.valid() and cacheEntry.first > std::chrono::high_resolution_clock::now())
+        if (cacheEntry.second.valid() && cacheEntry.first > std::chrono::high_resolution_clock::now())
         {
             futures[it.first] = cacheEntry.second;
         }
@@ -143,7 +143,7 @@ SoapySDR::Device* SoapySDR::Device::make(const Kwargs &inputArgs)
     Kwargs discoveredArgs;
     lock.unlock();
     const auto results = Device::enumerate(inputArgs);
-    if (not results.empty()) discoveredArgs = results.front();
+    if (!results.empty()) discoveredArgs = results.front();
     lock.lock();
 
     //check the device table for an already allocated device
@@ -161,7 +161,7 @@ SoapySDR::Device* SoapySDR::Device::make(const Kwargs &inputArgs)
     //unless there is only one available driver option
     const bool specifiedDriver = hybridArgs.count("driver") != 0;
     const auto makeFunctions = Registry::listMakeFunctions();
-    if (not specifiedDriver and makeFunctions.size() > 2) //more than factory: null + one loaded driver
+    if (!specifiedDriver && makeFunctions.size() > 2) //more than factory: null + one loaded driver
     {
         throw std::runtime_error("SoapySDR::Device::make() no driver specified and no enumeration results");
     }
@@ -171,16 +171,16 @@ SoapySDR::Device* SoapySDR::Device::make(const Kwargs &inputArgs)
     std::shared_future<Device *> deviceFuture;
     for (const auto &it : makeFunctions)
     {
-        if (not specifiedDriver and it.first == "null") continue; //skip null unless explicitly specified
-        if (specifiedDriver and hybridArgs.at("driver") != it.first) continue; //filter for driver match
+        if (!specifiedDriver && it.first == "null") continue; //skip null unless explicitly specified
+        if (specifiedDriver && hybridArgs.at("driver") != it.first) continue; //filter for driver match
         auto &cacheEntry = cache[discoveredArgs];
-        if (not cacheEntry.valid()) cacheEntry = std::async(std::launch::deferred, it.second, hybridArgs);
+        if (!cacheEntry.valid()) cacheEntry = std::async(std::launch::deferred, it.second, hybridArgs);
         deviceFuture = cacheEntry;
         break;
     }
 
     //no match found for the arguments in the loop above
-    if (not deviceFuture.valid()) throw std::runtime_error("SoapySDR::Device::make() no match");
+    if (!deviceFuture.valid()) throw std::runtime_error("SoapySDR::Device::make() no match");
 
     //unlock the mutex to block on the factory call
     lock.unlock();

--- a/lib/Modules.in.cpp
+++ b/lib/Modules.in.cpp
@@ -47,7 +47,7 @@ std::string getEnvImpl(const char *name)
 std::string SoapySDR::getRootPath(void)
 {
     const std::string rootPathEnv = getEnvImpl("@SOAPY_SDR_ROOT_ENV@");
-    if (not rootPathEnv.empty()) return rootPathEnv;
+    if (!rootPathEnv.empty()) return rootPathEnv;
 
     // Get the path to the current dynamic linked library.
     // The path to this library can be used to determine
@@ -66,7 +66,7 @@ std::string SoapySDR::getRootPath(void)
             const std::string libPath(path, size);
             const size_t slash0Pos = libPath.find_last_of("/\\");
             const size_t slash1Pos = libPath.substr(0, slash0Pos).find_last_of("/\\");
-            if (slash0Pos != std::string::npos and slash1Pos != std::string::npos)
+            if (slash0Pos != std::string::npos && slash1Pos != std::string::npos)
                 return libPath.substr(0, slash1Pos);
         }
     }
@@ -295,7 +295,7 @@ std::string SoapySDR::unloadModule(const std::string &path)
 #ifdef _WIN32
     BOOL success = FreeLibrary((HMODULE)handle);
     getModuleLoading().clear();
-    if (not success) return "FreeLibrary() failed: " + GetLastErrorMessage();
+    if (!success) return "FreeLibrary() failed: " + GetLastErrorMessage();
 #else
     int status = dlclose(handle);
     getModuleLoading().clear();
@@ -345,7 +345,7 @@ void SoapySDR::loadModules(void)
     {
         if (getModuleHandles().count(paths[i]) != 0) continue; //was manually loaded
         const std::string errorMsg = loadModule(paths[i]);
-        if (not errorMsg.empty()) SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::loadModule(%s)\n  %s", paths[i].c_str(), errorMsg.c_str());
+        if (!errorMsg.empty()) SoapySDR::logf(SOAPY_SDR_ERROR, "SoapySDR::loadModule(%s)\n  %s", paths[i].c_str(), errorMsg.c_str());
         for (const auto &it : SoapySDR::getLoaderResult(paths[i]))
         {
             if (it.second.empty()) continue;

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -8,8 +8,8 @@
 static std::string trim(const std::string &s)
 {
     std::string out = s;
-    while (not out.empty() and std::isspace(out[0])) out = out.substr(1);
-    while (not out.empty() and std::isspace(out[out.size()-1])) out = out.substr(0, out.size()-1);
+    while (!out.empty() && std::isspace(out[0])) out = out.substr(1);
+    while (!out.empty() && std::isspace(out[out.size()-1])) out = out.substr(0, out.size()-1);
     return out;
 }
 
@@ -33,11 +33,11 @@ SoapySDR::Kwargs SoapySDR::KwargsFromString(const std::string &markup)
             if (ch == ',') inKey = true;
             else val += ch;
         }
-        if ((inKey and (not val.empty() or (ch == ','))) or ((i+1) == markup.size()))
+        if ((inKey && (!val.empty() || (ch == ','))) || ((i+1) == markup.size()))
         {
             key = trim(key);
             val = trim(val);
-            if (not key.empty()) kwargs[key] = val;
+            if (!key.empty()) kwargs[key] = val;
             key = "";
             val = "";
         }
@@ -52,7 +52,7 @@ std::string SoapySDR::KwargsToString(const SoapySDR::Kwargs &args)
 
     for (const auto &pair : args)
     {
-        if (not markup.empty()) markup += ", ";
+        if (!markup.empty()) markup += ", ";
         markup += pair.first + "=" + pair.second;
     }
 

--- a/lib/TypesC.cpp
+++ b/lib/TypesC.cpp
@@ -60,7 +60,7 @@ int SoapySDRKwargs_set(SoapySDRKwargs *args, const char *key, const char *val)
     if (new_vals != nullptr) args->vals = new_vals;
 
     //error: the current allocation has no space for the new element
-    if (new_keys == nullptr or new_vals == nullptr) return -1;
+    if (new_keys == nullptr || new_vals == nullptr) return -1;
 
     //make copies of the key and value to store
     auto new_key = strdup(key);
@@ -68,7 +68,7 @@ int SoapySDRKwargs_set(SoapySDRKwargs *args, const char *key, const char *val)
 
     //error: could not make a copy of the key or value string
     //free both pointers in case one of them was allocated
-    if (new_key == nullptr or new_val == nullptr)
+    if (new_key == nullptr || new_val == nullptr)
     {
         SoapySDR_free(new_key);
         SoapySDR_free(new_val);

--- a/tests/TestKwargsMarkup.cpp
+++ b/tests/TestKwargsMarkup.cpp
@@ -32,8 +32,8 @@ int main(void)
     #define checkArgsEq(lhs, rhs) \
     { \
         printf("Test line %d\n", __LINE__); \
-        if (not checkArgsInLhs__(lhs, rhs)) return EXIT_FAILURE; \
-        if (not checkArgsInLhs__(rhs, lhs)) return EXIT_FAILURE; \
+        if (!checkArgsInLhs__(lhs, rhs)) return EXIT_FAILURE; \
+        if (!checkArgsInLhs__(rhs, lhs)) return EXIT_FAILURE; \
     }
 
     //string to args - empty string

--- a/tests/TestTimeConversion.cpp
+++ b/tests/TestTimeConversion.cpp
@@ -58,14 +58,14 @@ int main(void)
     for (size_t i = 0; i < 100; i++)
     {
         const long long timeNs = rand64bits();
-        if (not loopbackTimeToTicks(timeNs, 1e9)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(-timeNs, 1e9)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(timeNs, 52e6)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(-timeNs, 52e6)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(timeNs, 61.44e6)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(-timeNs, 61.44e6)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(timeNs, 100e6/3)) return EXIT_FAILURE;
-        if (not loopbackTimeToTicks(-timeNs, 100e6/3)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(timeNs, 1e9)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(-timeNs, 1e9)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(timeNs, 52e6)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(-timeNs, 52e6)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(timeNs, 61.44e6)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(-timeNs, 61.44e6)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(timeNs, 100e6/3)) return EXIT_FAILURE;
+        if (!loopbackTimeToTicks(-timeNs, 100e6/3)) return EXIT_FAILURE;
     }
     printf("OK\n");
 
@@ -74,14 +74,14 @@ int main(void)
     for (size_t i = 0; i < 100; i++)
     {
         const long long ticks = rand64bits() >> 8; //room for max rate
-        if (not loopbackTicksToTime(ticks, 1e9)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(-ticks, 1e9)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(ticks, 52e6)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(-ticks, 52e6)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(ticks, 61.44e6)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(-ticks, 61.44e6)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(ticks, 100e6/3)) return EXIT_FAILURE;
-        if (not loopbackTicksToTime(-ticks, 100e6/3)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(ticks, 1e9)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(-ticks, 1e9)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(ticks, 52e6)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(-ticks, 52e6)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(ticks, 61.44e6)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(-ticks, 61.44e6)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(ticks, 100e6/3)) return EXIT_FAILURE;
+        if (!loopbackTicksToTime(-ticks, 100e6/3)) return EXIT_FAILURE;
     }
     printf("OK\n");
 


### PR DESCRIPTION
Replaces all alternative operator representations (`and`, `or`, `not`).
Removes the need for a ciso646 include, which was needed for MSVC though deprecated in other modern compilers.