### PR TITLE
CMakeLists.txt: bump minimum CMake required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.3...3.10)
+cmake_minimum_required(VERSION 3.5...3.10)
 project(SoapySDR)
 enable_language(CXX)
 enable_testing()

--- a/ExampleDriver/CMakeLists.txt
+++ b/ExampleDriver/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project setup -- only needed if device support is a stand-alone build
 # We recommend that the support module be built in-tree with the driver.
 ########################################################################
-cmake_minimum_required(VERSION 3.3...3.10)
+cmake_minimum_required(VERSION 3.5...3.10)
 project(SoapySDRMyDevice CXX)
 enable_testing()
 

--- a/luajit/CMakeLists.txt
+++ b/luajit/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.3...3.10)
+cmake_minimum_required(VERSION 3.5...3.10)
 project(SoapySDRLuaJIT)
 enable_testing()
 

--- a/swig/csharp/apps/CMakeLists.txt
+++ b/swig/csharp/apps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3...3.10)
+cmake_minimum_required(VERSION 3.5...3.10)
 project(SoapySDRCSharpApps CSharp)
 
 function(CSHARP_BUILD_APP name)

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.3...3.10)
+cmake_minimum_required(VERSION 3.5...3.10)
 project(SoapySDRPython CXX)
 enable_testing()
 


### PR DESCRIPTION
Building with CMake >= 4 requires a minimum version of at least 3.5, otherwise the build fails with:

CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.